### PR TITLE
Better slots on geoscape screen

### DIFF
--- a/CovertInfiltration/CovertInfiltration.x2proj
+++ b/CovertInfiltration/CovertInfiltration.x2proj
@@ -51,6 +51,9 @@
     <Content Include="Src\CovertInfiltration\Classes\CI_UIStrategyMapItem_CovertAction.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\CovertInfiltration\Classes\UICovertActionsGeoscape_SlotInfo.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\CovertInfiltration\Classes\UICovertActionsGeoscape_ResourcesHook.uc">
       <SubType>Content</SubType>
     </Content>

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
@@ -591,21 +591,43 @@ simulated protected function UpdateSlots()
 	local UICovertActionsGeoscape_SlotInfo SlotInfo;
 	local UICovertActionsGeoscape_SlotRow Row;
 	local UICovertActionsGeoscape_Slot SlotUI;
-	local int iCurrentSlot;
+	local int iCurrentSlot, iCurrentRow;
+	local int TotalNeededRows;
 
-	PrepareSlotsUI();
+	TotalNeededRows = FCeil(CurrentSlots.Length / float(ACTION_SLOTS_PER_ROW));
 
+	// Show/Spawn rows we need
+	for (iCurrentRow = 0; iCurrentRow < TotalNeededRows; iCurrentRow++)
+	{
+		if (iCurrentRow == ActionSlotRows.GetItemCount())
+		{
+			Row = Spawn(class'UICovertActionsGeoscape_SlotRow', ActionSlotRows.ItemContainer);
+			Row.NumSlots = ACTION_SLOTS_PER_ROW;
+			Row.InitRow();
+			Row.SetWidth(ActionSlotRows.Width);
+			Row.CreateSlots();
+		}
+
+		ActionSlotRows.GetItem(iCurrentRow).Show();
+	}
+
+	// Hide extra rows
+	for (iCurrentRow = TotalNeededRows; iCurrentRow < ActionSlotRows.GetItemCount(); iCurrentRow++)
+	{
+		ActionSlotRows.GetItem(iCurrentRow).Hide();
+	}
+
+	// Update used slots with curent info
 	foreach CurrentSlots(SlotInfo, iCurrentSlot)
 	{
 		Row = UICovertActionsGeoscape_SlotRow(ActionSlotRows.GetItem(iCurrentSlot / ACTION_SLOTS_PER_ROW));
 		SlotUI = Row.Slots[iCurrentSlot % ACTION_SLOTS_PER_ROW];
+		
 		SlotUI.UpdateFromInfo(SlotInfo);
-
-		Row.Show();
 		SlotUI.Show();
 	}
 
-	// Hide unsed slots in current row
+	// Hide unused slots in current row
 	for (iCurrentSlot = (iCurrentSlot % ACTION_SLOTS_PER_ROW) + 1; iCurrentSlot < Row.Slots.Length; iCurrentSlot++)
 	{
 		Row.Slots[iCurrentSlot].Hide();
@@ -656,42 +678,6 @@ simulated protected function PrepareSlotsInfo()
 		SlotInfo.SetCostSlot(CostSlot);
 
 		CurrentSlots.AddItem(SlotInfo);
-	}
-}
-
-simulated protected function PrepareSlotsUI()
-{
-	local UICovertActionsGeoscape_SlotRow Row;
-	local int TotalNeededRows, NumExistingRows;
-	local int i;
-
-	TotalNeededRows = FCeil(CurrentSlots.Length / float(ACTION_SLOTS_PER_ROW));
-	NumExistingRows = ActionSlotRows.GetItemCount();
-
-	if (TotalNeededRows > NumExistingRows)
-	{
-		// Add more
-
-		for (i = NumExistingRows - 1; i < TotalNeededRows; i++)
-		{
-			Row = Spawn(class'UICovertActionsGeoscape_SlotRow', ActionSlotRows.ItemContainer);
-			Row.NumSlots = ACTION_SLOTS_PER_ROW;
-			Row.InitRow();
-			Row.SetWidth(ActionSlotRows.Width);
-			Row.CreateSlots();
-			Row.Hide();
-		}
-	}
-	else if (TotalNeededRows < NumExistingRows)
-	{
-		// Hide unused ones
-		// TotalUsedRows is 1-based and i is zero based and since we want to 
-		// start from [the row after TotalUsedRows] we just start i from TotalUsedRows
-
-		for (i = TotalNeededRows; i < NumExistingRows; i++)
-		{
-			ActionSlotRows.GetItem(i).Hide();
-		}
 	}
 }
 

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
@@ -59,6 +59,7 @@ var UIText ActionRisksText;
 var StateObjectReference ActionRef;
 var array<XComGameState_CovertAction> arrActions;
 var StateObjectReference ActionToShowOnInitRef;
+var protected array<UICovertActionsGeoscape_SlotInfo> CurrentSlots;
 
 // SquadSelect manager
 var protectedwrite UISSManager_CovertAction SSManager;
@@ -524,6 +525,8 @@ simulated function UpdateList()
 simulated function UpdateData()
 {
 	if (bDontUpdateData) return;
+	
+	PrepareSlotsInfo();
 
 	FocusCameraOnCurrentAction();
 	ConfirmButton.SetDisabled(!CanOpenLoadout());
@@ -533,11 +536,36 @@ simulated function UpdateData()
 simulated function bool CanOpenLoadout()
 {
 	local XComGameState_CovertAction CurrentAction;
+	local UICovertActionsGeoscape_SlotInfo SlotInfo;
+	local bool UnaffordableRequiredSlot;
+
 	CurrentAction = GetAction();
 
-	return 
-		!CurrentAction.bStarted &&
-		CurrentAction.RequiredFactionInfluence <= CurrentAction.GetFaction().GetInfluence();
+	if (CurrentAction.bStarted)
+	{
+		return false;
+	}
+
+	if (CurrentAction.RequiredFactionInfluence > CurrentAction.GetFaction().GetInfluence())
+	{
+		return false;
+	}
+
+	foreach CurrentSlots(SlotInfo)
+	{
+		if (!SlotInfo.CanAfford() && !SlotInfo.IsOptional())
+		{
+			UnaffordableRequiredSlot = true;
+			break;
+		}
+	}
+
+	if (UnaffordableRequiredSlot)
+	{
+		return false;
+	}
+
+	return true;
 }
 
 simulated function UpdateCovertActionInfo()
@@ -560,99 +588,109 @@ simulated function UpdateCovertActionInfo()
 
 simulated protected function UpdateSlots()
 {
-	// TODO: Adjust the display on already deployed CAs
-
-	local XComGameState_CovertAction CurrentAction;
-	local CovertActionStaffSlot StaffSlot;
-	local CovertActionCostSlot CostSlot;
-	
+	local UICovertActionsGeoscape_SlotInfo SlotInfo;
 	local UICovertActionsGeoscape_SlotRow Row;
 	local UICovertActionsGeoscape_Slot SlotUI;
-	local int iCurrentSlot, i;
+	local int iCurrentSlot;
 
-	CurrentAction = GetAction();
-	iCurrentSlot = -1;
+	PrepareSlotsUI();
 
-	EnsureEnoughSlotRows();
-
-	foreach CurrentAction.StaffSlots(StaffSlot)
+	foreach CurrentSlots(SlotInfo, iCurrentSlot)
 	{
-		iCurrentSlot++;
-		
 		Row = UICovertActionsGeoscape_SlotRow(ActionSlotRows.GetItem(iCurrentSlot / ACTION_SLOTS_PER_ROW));
 		SlotUI = Row.Slots[iCurrentSlot % ACTION_SLOTS_PER_ROW];
+		SlotUI.UpdateFromInfo(SlotInfo);
 
 		Row.Show();
 		SlotUI.Show();
-		SlotUI.UpdateStaffSlot(StaffSlot);
+	}
+
+	// Hide unsed slots in current row
+	for (iCurrentSlot = (iCurrentSlot % ACTION_SLOTS_PER_ROW) + 1; iCurrentSlot < Row.Slots.Length; iCurrentSlot++)
+	{
+		Row.Slots[iCurrentSlot].Hide();
+	}
+}
+
+simulated protected function PrepareSlotsInfo()
+{
+	local XComGameState_CovertAction CurrentAction;
+	local UICovertActionsGeoscape_SlotInfo SlotInfo;
+
+	local CovertActionStaffSlot StaffSlot;
+	local CovertActionCostSlot CostSlot;
+
+	CurrentAction = GetAction();
+	CurrentSlots.Length = 0;
+
+	foreach CurrentAction.StaffSlots(StaffSlot)
+	{
+		if (
+			CurrentAction.bStarted &&
+			XComGameState_StaffSlot(`XCOMHISTORY.GetGameStateForObjectID(StaffSlot.StaffSlotRef.ObjectID)).IsSlotEmpty()
+		)
+		{
+			// Do not show empty slots on already deployed ops
+			continue;
+		}
+
+		SlotInfo = new class'UICovertActionsGeoscape_SlotInfo';
+		SlotInfo.ShowPrefix = !CurrentAction.bStarted;
+		SlotInfo.SetStaffSlot(StaffSlot);
+
+		CurrentSlots.AddItem(SlotInfo);
 	}
 
 	foreach CurrentAction.CostSlots(CostSlot)
 	{
-		iCurrentSlot++;
-		
-		Row = UICovertActionsGeoscape_SlotRow(ActionSlotRows.GetItem(iCurrentSlot / ACTION_SLOTS_PER_ROW));
-		SlotUI = Row.Slots[iCurrentSlot % ACTION_SLOTS_PER_ROW];
+		if (CurrentAction.bStarted && !CostSlot.bPurchased)
+		{
+			// Do not show empty slots on already deployed ops
+			continue;
+		}
 
-		Row.Show();
-		SlotUI.Show();
-		SlotUI.UpdateCostSlot(CostSlot);
-	}
+		SlotInfo = new class'UICovertActionsGeoscape_SlotInfo';
+		SlotInfo.ShowPrefix = !CurrentAction.bStarted;
+		SlotInfo.SetCostSlot(CostSlot);
 
-	HideUnusedSlotRows();
-
-	// Hide unsed slots in current row
-	for (i = (iCurrentSlot % ACTION_SLOTS_PER_ROW) + 1; i < Row.Slots.Length; i++)
-	{
-		Row.Slots[i].Hide();
+		CurrentSlots.AddItem(SlotInfo);
 	}
 }
 
-simulated protected function EnsureEnoughSlotRows()
+simulated protected function PrepareSlotsUI()
 {
 	local UICovertActionsGeoscape_SlotRow Row;
-	local int TotalRows;
+	local int TotalNeededRows, NumExistingRows;
 	local int i;
 
-	TotalRows = GetNumNeededSlotRows();
+	TotalNeededRows = FCeil(CurrentSlots.Length / float(ACTION_SLOTS_PER_ROW));
+	NumExistingRows = ActionSlotRows.GetItemCount();
 
-	for (i = ActionSlotRows.GetItemCount() - 1; i < TotalRows; i++)
+	if (TotalNeededRows > NumExistingRows)
 	{
-		Row = Spawn(class'UICovertActionsGeoscape_SlotRow', ActionSlotRows.ItemContainer);
-		Row.NumSlots = ACTION_SLOTS_PER_ROW;
-		Row.InitRow();
-		Row.SetWidth(ActionSlotRows.Width);
-		Row.CreateSlots();
-		Row.Hide();
+		// Add more
+
+		for (i = NumExistingRows - 1; i < TotalNeededRows; i++)
+		{
+			Row = Spawn(class'UICovertActionsGeoscape_SlotRow', ActionSlotRows.ItemContainer);
+			Row.NumSlots = ACTION_SLOTS_PER_ROW;
+			Row.InitRow();
+			Row.SetWidth(ActionSlotRows.Width);
+			Row.CreateSlots();
+			Row.Hide();
+		}
 	}
-}
-
-simulated protected function HideUnusedSlotRows()
-{
-	local int TotalUsedRows;
-	local int i;
-
-	TotalUsedRows = GetNumNeededSlotRows();
-
-	// TotalUsedRows is 1-based and i is zero based and since we want to 
-	// start from [the row after TotalUsedRows] we just start i from TotalUsedRows
-
-	for (i = TotalUsedRows; i < ActionSlotRows.GetItemCount(); i++)
+	else if (TotalNeededRows < NumExistingRows)
 	{
-		ActionSlotRows.GetItem(i).Hide();
+		// Hide unused ones
+		// TotalUsedRows is 1-based and i is zero based and since we want to 
+		// start from [the row after TotalUsedRows] we just start i from TotalUsedRows
+
+		for (i = TotalNeededRows; i < NumExistingRows; i++)
+		{
+			ActionSlotRows.GetItem(i).Hide();
+		}
 	}
-}
-
-simulated protected function int GetNumNeededSlotRows()
-{
-	local XComGameState_CovertAction CurrentAction;
-	local int TotalSlots, TotalRows;
-
-	CurrentAction = GetAction();
-	TotalSlots = CurrentAction.StaffSlots.Length + CurrentAction.CostSlots.Length;
-	TotalRows = FCeil(TotalSlots / float(ACTION_SLOTS_PER_ROW));
-
-	return TotalRows;
 }
 
 simulated protected function UpdateRisks()
@@ -817,6 +855,10 @@ simulated function bool OnUnrealCommand(int cmd, int arg)
 		if (CanOpenLoadout())
 		{
 			ConfirmButton.OnClickedDelegate(ConfirmButton);
+		}
+		else
+		{
+			class'UIUtilities_Sound'.static.PlayNegativeSound();
 		}
 		return true;
 

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
@@ -636,6 +636,7 @@ simulated protected function PrepareSlotsInfo()
 
 		SlotInfo = new class'UICovertActionsGeoscape_SlotInfo';
 		SlotInfo.ShowPrefix = !CurrentAction.bStarted;
+		SlotInfo.ColourDescription = !CurrentAction.bStarted;
 		SlotInfo.SetStaffSlot(StaffSlot);
 
 		CurrentSlots.AddItem(SlotInfo);
@@ -651,6 +652,7 @@ simulated protected function PrepareSlotsInfo()
 
 		SlotInfo = new class'UICovertActionsGeoscape_SlotInfo';
 		SlotInfo.ShowPrefix = !CurrentAction.bStarted;
+		SlotInfo.ColourDescription = !CurrentAction.bStarted;
 		SlotInfo.SetCostSlot(CostSlot);
 
 		CurrentSlots.AddItem(SlotInfo);

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
@@ -658,7 +658,7 @@ simulated protected function PrepareSlotsInfo()
 
 		SlotInfo = new class'UICovertActionsGeoscape_SlotInfo';
 		SlotInfo.ShowPrefix = !CurrentAction.bStarted;
-		SlotInfo.ColourDescription = !CurrentAction.bStarted;
+		SlotInfo.ColorDescription = !CurrentAction.bStarted;
 		SlotInfo.SetStaffSlot(StaffSlot);
 
 		CurrentSlots.AddItem(SlotInfo);
@@ -674,7 +674,7 @@ simulated protected function PrepareSlotsInfo()
 
 		SlotInfo = new class'UICovertActionsGeoscape_SlotInfo';
 		SlotInfo.ShowPrefix = !CurrentAction.bStarted;
-		SlotInfo.ColourDescription = !CurrentAction.bStarted;
+		SlotInfo.ColorDescription = !CurrentAction.bStarted;
 		SlotInfo.SetCostSlot(CostSlot);
 
 		CurrentSlots.AddItem(SlotInfo);

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_Slot.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_Slot.uc
@@ -30,7 +30,7 @@ simulated function InitSlot(float InitWidth)
 
 simulated function UpdateFromInfo(UICovertActionsGeoscape_SlotInfo SlotInfo)
 {
-	UpdateDescription(GetDescriptionFromInfo(SlotInfo), SlotInfo.CanAfford());
+	UpdateDescription(GetDescriptionFromInfo(SlotInfo), SlotInfo.CanAfford(), SlotInfo.ColourDescription);
 	UpdateReward(SlotInfo.GetReward());
 }
 
@@ -63,8 +63,7 @@ simulated function string GetDescriptionFromInfo(UICovertActionsGeoscape_SlotInf
 	{
 		CostScalars.Length = 0; // Prevent compiler warning as we want empty array
 		
-		// TODO: Disable GetStrategyCostString's colouring
-		strDescription = class'UIUtilities_Strategy'.static.GetStrategyCostString(SlotInfo.CostSlotInfo.Cost, CostScalars);
+		strDescription = class'UIUtilities_Infiltration'.static.GetStrategyCostStringNoColours(SlotInfo.CostSlotInfo.Cost, CostScalars);
 		strPrefix = class'UICovertActionStaffSlot'.default.m_strOptionalSlot;
 	}
 
@@ -76,12 +75,16 @@ simulated function string GetDescriptionFromInfo(UICovertActionsGeoscape_SlotInf
 	return strDescription;
 }
 
-simulated function UpdateDescription(string strDescription, bool CanFullfil)
+simulated function UpdateDescription(string strDescription, bool CanFullfil, optional bool ColourText = true)
 {
 	local EUIState eState;
-	eState = CanFullfil ? eUIState_Normal : eUIState_Bad;
 	
-	strDescription = class'UIUtilities_Text'.static.GetColoredText(strDescription, eState);
+	if (ColourText)
+	{
+		eState = CanFullfil ? eUIState_Normal : eUIState_Bad;
+		strDescription = class'UIUtilities_Text'.static.GetColoredText(strDescription, eState);
+	}
+
 	Description.SetText(strDescription);
 }
 

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_Slot.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_Slot.uc
@@ -30,7 +30,7 @@ simulated function InitSlot(float InitWidth)
 
 simulated function UpdateFromInfo(UICovertActionsGeoscape_SlotInfo SlotInfo)
 {
-	UpdateDescription(GetDescriptionFromInfo(SlotInfo), SlotInfo.CanAfford(), SlotInfo.ColourDescription);
+	UpdateDescription(GetDescriptionFromInfo(SlotInfo), SlotInfo.CanAfford(), SlotInfo.ColorDescription);
 	UpdateReward(SlotInfo.GetReward());
 }
 
@@ -63,7 +63,7 @@ simulated function string GetDescriptionFromInfo(UICovertActionsGeoscape_SlotInf
 	{
 		CostScalars.Length = 0; // Prevent compiler warning as we want empty array
 		
-		strDescription = class'UIUtilities_Infiltration'.static.GetStrategyCostStringNoColours(SlotInfo.CostSlotInfo.Cost, CostScalars);
+		strDescription = class'UIUtilities_Infiltration'.static.GetStrategyCostStringNoColors(SlotInfo.CostSlotInfo.Cost, CostScalars);
 		strPrefix = class'UICovertActionStaffSlot'.default.m_strOptionalSlot;
 	}
 
@@ -75,11 +75,11 @@ simulated function string GetDescriptionFromInfo(UICovertActionsGeoscape_SlotInf
 	return strDescription;
 }
 
-simulated function UpdateDescription(string strDescription, bool CanFullfil, optional bool ColourText = true)
+simulated function UpdateDescription(string strDescription, bool CanFullfil, optional bool ColorText = true)
 {
 	local EUIState eState;
 	
-	if (ColourText)
+	if (ColorText)
 	{
 		eState = CanFullfil ? eUIState_Normal : eUIState_Bad;
 		strDescription = class'UIUtilities_Text'.static.GetColoredText(strDescription, eState);

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_Slot.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_Slot.uc
@@ -8,73 +8,72 @@
 
 class UICovertActionsGeoscape_Slot extends UIPanel;
 
-var protectedwrite UIText Description;
-var protectedwrite UIText RewardText;
+var protectedwrite UIScrollingText Description;
+var protectedwrite UIScrollingText RewardText;
 
 simulated function InitSlot(float InitWidth)
 {
 	InitPanel();
 	SetWidth(InitWidth);
 
-	Description = Spawn(class'UIText', self);
+	Description = Spawn(class'UIScrollingText', self);
 	Description.bAnimateOnInit = false;
-	Description.InitText('Description');
+	Description.InitScrollingText('Description');
 	Description.SetWidth(Width);
 
-	RewardText = Spawn(class'UIText', self);
+	RewardText = Spawn(class'UIScrollingText', self);
 	RewardText.bAnimateOnInit = false;
-	RewardText.InitText('RewardText');
+	RewardText.InitScrollingText('RewardText');
 	RewardText.SetY(23);
 	RewardText.SetWidth(Width);
 }
 
-simulated function UpdateCostSlot(CovertActionCostSlot CostSlotInfo)
+simulated function UpdateFromInfo(UICovertActionsGeoscape_SlotInfo SlotInfo)
 {
-	local XComGameStateHistory History;
-	local XComGameState_HeadquartersXCom XComHQ;
-	local StrategyCost Cost;
-	local array<StrategyCostScalar> CostScalars;
-	local string strDescription;
-
-	History = `XCOMHISTORY;
-	Cost = CostSlotInfo.Cost;
-	CostScalars.Length = 0; // Prevent compiler warnning as we want empty array
-	XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
-
-	// TODO: this colours the text green if it's affordable, make it white instead
-	strDescription = class'UIUtilities_Strategy'.static.GetStrategyCostString(Cost, CostScalars);
-	strDescription = class'UICovertActionStaffSlot'.default.m_strOptionalSlot @ strDescription;
-
-	UpdateDescription(strDescription, XComHQ.CanAffordAllStrategyCosts(Cost, CostScalars));
-	UpdateReward(XComGameState_Reward(History.GetGameStateForObjectID(CostSlotInfo.RewardRef.ObjectID)));
+	UpdateDescription(GetDescriptionFromInfo(SlotInfo), SlotInfo.CanAfford());
+	UpdateReward(SlotInfo.GetReward());
 }
 
-simulated function UpdateStaffSlot(CovertActionStaffSlot StaffSlotInfo)
+simulated function string GetDescriptionFromInfo(UICovertActionsGeoscape_SlotInfo SlotInfo)
 {
-	local XComGameStateHistory History;
-	local XComGameState_StaffSlot StaffSlot;
-	local string strDescription;
+	local string strDescription, strPrefix;
+	
+	// Cost slots
+	local array<StrategyCostScalar> CostScalars;
 
-	History = `XCOMHISTORY;
-	StaffSlot = XComGameState_StaffSlot(History.GetGameStateForObjectID(StaffSlotInfo.StaffSlotRef.ObjectID));
-	strDescription = StaffSlot.GetNameDisplayString();
-
-	if (StaffSlotInfo.bFame)
+	if (SlotInfo.IsStaffSlot)
 	{
-		strDescription = class'UICovertActionStaffSlot'.default.m_strFamous @ strDescription;
-	}
+		strDescription = SlotInfo.GetStaffSlotState().GetNameDisplayString();
 
-	if (StaffSlotInfo.bOptional)
-	{
-		strDescription = class'UICovertActionStaffSlot'.default.m_strOptionalSlot @ strDescription;
+		if (SlotInfo.StaffSlotInfo.bFame)
+		{
+			strDescription = class'UICovertActionStaffSlot'.default.m_strFamous @ strDescription;
+		}
+
+		if (SlotInfo.StaffSlotInfo.bOptional)
+		{
+			strPrefix = class'UICovertActionStaffSlot'.default.m_strOptionalSlot;
+		}
+		else
+		{
+			strPrefix = class'UICovertActionStaffSlot'.default.m_strRequiredSlot;
+		}
 	}
 	else
 	{
-		strDescription = class'UICovertActionStaffSlot'.default.m_strRequiredSlot @ strDescription;
+		CostScalars.Length = 0; // Prevent compiler warning as we want empty array
+		
+		// TODO: Disable GetStrategyCostString's colouring
+		strDescription = class'UIUtilities_Strategy'.static.GetStrategyCostString(SlotInfo.CostSlotInfo.Cost, CostScalars);
+		strPrefix = class'UICovertActionStaffSlot'.default.m_strOptionalSlot;
 	}
 
-	UpdateDescription(strDescription, StaffSlot.IsUnitAvailableForThisSlot());
-	UpdateReward(XComGameState_Reward(History.GetGameStateForObjectID(StaffSlotInfo.RewardRef.ObjectID)));
+	if (SlotInfo.ShowPrefix)
+	{
+		strDescription = strPrefix @ strDescription;
+	}
+
+	return strDescription;
 }
 
 simulated function UpdateDescription(string strDescription, bool CanFullfil)

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_SlotInfo.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_SlotInfo.uc
@@ -12,7 +12,7 @@
 class UICovertActionsGeoscape_SlotInfo extends Object;
 
 var bool ShowPrefix; // Show "REQUIRED:" or "OPTIONAL:" prefix. Used for ongoing CAs
-var bool ColourDescription;
+var bool ColorDescription;
 
 var protectedwrite bool IsStaffSlot;
 var protectedwrite CovertActionStaffSlot StaffSlotInfo;

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_SlotInfo.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_SlotInfo.uc
@@ -1,6 +1,18 @@
+//---------------------------------------------------------------------------------------
+//  AUTHOR:  Xymanek
+//  PURPOSE: This is a information holder for a single slot on the UICovertActionsGeoscape
+//           screen which handles both personnel and cost slots (but not both at the 
+//           same time).
+//           Separate class to simply logic in UICovertActionsGeoscape (since the info is
+//           needed in various places)
+//---------------------------------------------------------------------------------------
+//  WOTCStrategyOverhaul Team
+//---------------------------------------------------------------------------------------
+
 class UICovertActionsGeoscape_SlotInfo extends Object;
 
 var bool ShowPrefix; // Show "REQUIRED:" or "OPTIONAL:" prefix. Used for ongoing CAs
+var bool ColourDescription;
 
 var protectedwrite bool IsStaffSlot;
 var protectedwrite CovertActionStaffSlot StaffSlotInfo;

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_SlotInfo.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_SlotInfo.uc
@@ -1,0 +1,72 @@
+class UICovertActionsGeoscape_SlotInfo extends Object;
+
+var bool ShowPrefix; // Show "REQUIRED:" or "OPTIONAL:" prefix. Used for ongoing CAs
+
+var protectedwrite bool IsStaffSlot;
+var protectedwrite CovertActionStaffSlot StaffSlotInfo;
+var protectedwrite CovertActionCostSlot CostSlotInfo;
+
+simulated function SetStaffSlot(CovertActionStaffSlot InStaffSlotInfo)
+{
+	local CovertActionCostSlot DummyCostSlot;
+
+	IsStaffSlot = true;
+	StaffSlotInfo = InStaffSlotInfo;
+	CostSlotInfo = DummyCostSlot;
+}
+
+simulated function SetCostSlot(CovertActionCostSlot InCostSlotInfo)
+{
+	local CovertActionStaffSlot DummyStaffSlot;
+
+	IsStaffSlot = false;
+	StaffSlotInfo = DummyStaffSlot;
+	CostSlotInfo = InCostSlotInfo;
+}
+
+simulated function bool IsOptional()
+{
+	if (!IsStaffSlot) 
+	{
+		// Costs/resource slots are always optional
+		return false;
+	}
+
+	return StaffSlotInfo.bOptional;
+}
+
+simulated function bool CanAfford()
+{
+	local XComGameState_HeadquartersXCom XComHQ;
+	local array<StrategyCostScalar> CostScalars;
+
+	if (IsStaffSlot)
+	{
+		return GetStaffSlotState().IsUnitAvailableForThisSlot();
+	}
+
+	XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
+	CostScalars.Length = 0; // Prevent compiler warnning as we want empty array
+
+	return XComHQ.CanAffordAllStrategyCosts(CostSlotInfo.Cost, CostScalars);
+}
+
+simulated function XComGameState_StaffSlot GetStaffSlotState()
+{
+	if (!IsStaffSlot)
+	{
+		`REDSCREEN("Cannot call GetStaffSlotState for a cost slot");
+		`REDSCREEN(GetScriptTrace());
+		return none;
+	}
+
+	return XComGameState_StaffSlot(`XCOMHISTORY.GetGameStateForObjectID(StaffSlotInfo.StaffSlotRef.ObjectID));
+}
+
+simulated function XComGameState_Reward GetReward()
+{
+	local StateObjectReference RewardRef;
+	RewardRef = IsStaffSlot ? StaffSlotInfo.RewardRef : CostSlotInfo.RewardRef;
+
+	return XComGameState_Reward(`XCOMHISTORY.GetGameStateForObjectID(RewardRef.ObjectID));
+}

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_SlotRow.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape_SlotRow.uc
@@ -43,4 +43,5 @@ defaultproperties
 	SpaceBetweenSlots = 10;
 	
 	Height = 52;
+	bAnimateOnInit = false;
 }

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UIUtilities_Infiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UIUtilities_Infiltration.uc
@@ -115,3 +115,61 @@ protected static function int SortRisksByDifficulty(CovertActionRisk a, CovertAc
 	else
 		return 0;
 }
+
+// Does same thing as UIUtilities_Strategy::GetStrategyCostString but doesn't colour the text
+static function String GetStrategyCostStringNoColours(StrategyCost StratCost, array<StrategyCostScalar> CostScalars, optional float DiscountPercent)
+{
+	local int iResource, iArtifact, Quantity;
+	local String strCost, strResourceCost, strArtifactCost;
+	local StrategyCost ScaledStratCost;
+	local XComGameState_HeadquartersXCom XComHQ;
+
+	XComHQ = class'UIUtilities_Strategy'.static.GetXComHQ();
+	ScaledStratCost = XComHQ.GetScaledStrategyCost(StratCost, CostScalars, DiscountPercent);
+
+	for (iArtifact = 0; iArtifact < ScaledStratCost.ArtifactCosts.Length; iArtifact++)
+	{
+		Quantity = ScaledStratCost.ArtifactCosts[iArtifact].Quantity;
+		strArtifactCost = String(Quantity) @ class'UIUtilities_Strategy'.static.GetResourceDisplayName(ScaledStratCost.ArtifactCosts[iArtifact].ItemTemplateName, Quantity);
+
+		if (iArtifact < ScaledStratCost.ArtifactCosts.Length - 1)
+		{
+			strArtifactCost $= ",";
+		}
+		else if (ScaledStratCost.ResourceCosts.Length > 0)
+		{
+			strArtifactCost $= ",";
+		}
+
+		if (strCost == "")
+		{
+			strCost $= strArtifactCost; 
+		}
+		else
+		{
+			strCost @= strArtifactCost;
+		}
+	}
+
+	for (iResource = 0; iResource < ScaledStratCost.ResourceCosts.Length; iResource++)
+	{
+		Quantity = ScaledStratCost.ResourceCosts[iResource].Quantity;
+		strResourceCost = String(Quantity) @ class'UIUtilities_Strategy'.static.GetResourceDisplayName(ScaledStratCost.ResourceCosts[iResource].ItemTemplateName, Quantity);
+
+		if (iResource < ScaledStratCost.ResourceCosts.Length - 1)
+		{
+			strResourceCost $= ",";
+		}
+
+		if (strCost == "")
+		{
+			strCost $= strResourceCost;
+		}
+		else
+		{
+			strCost @= strResourceCost;
+		}
+	}
+
+	return class'UIUtilities_Text'.static.FormatCommaSeparatedNouns(strCost);
+}

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UIUtilities_Infiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UIUtilities_Infiltration.uc
@@ -117,7 +117,7 @@ protected static function int SortRisksByDifficulty(CovertActionRisk a, CovertAc
 }
 
 // Does same thing as UIUtilities_Strategy::GetStrategyCostString but doesn't colour the text
-static function String GetStrategyCostStringNoColours(StrategyCost StratCost, array<StrategyCostScalar> CostScalars, optional float DiscountPercent)
+static function String GetStrategyCostStringNoColors(StrategyCost StratCost, array<StrategyCostScalar> CostScalars, optional float DiscountPercent)
 {
 	local int iResource, iArtifact, Quantity;
 	local String strCost, strResourceCost, strArtifactCost;


### PR DESCRIPTION
* Made the logic a bit cleaner
* Hid required/optional prefix for ongoing CAs
* Converted text to scrolling
* Disabled "go to loadout" when a required slot cannot be filled + sound for keyboard/controller press when disabled
* Removed default costs colouring

Closes #19, #11 