### PR TITLE
Schedule for non-abandoned/non-lost ambushes

### DIFF
--- a/CovertInfiltration/Config/XComMissionDefs.ini
+++ b/CovertInfiltration/Config/XComMissionDefs.ini
@@ -38,6 +38,7 @@
 	bIsTacticalObjective=false, bIsStrategyObjective=false, bIsTriadObjective=true), \\
 	OverrideDefaultMissionIntro=true, \\
 	MissionSchedules[0]="Covert_Escape_CI", \\
+	MissionSchedules[1]="Covert_Escape_CI_Lost", \\
 	MaxSoldiers=3, \\
 	DisallowUITimerSuspension=true, \\
 	ForcedTacticalTags[0]="NoVolunteerArmy", \\

--- a/CovertInfiltration/Config/XComSchedules.ini
+++ b/CovertInfiltration/Config/XComSchedules.ini
@@ -2,8 +2,9 @@
 
 ; For now lowered the min distance since the objective location is now the center of the objective parcel, not the evac itself
 ; The IdealXComSpawnDistance should still give heavy preference to spawns further away
-+MissionSchedules=(ScheduleID="Covert_Escape_CI", \\
++MissionSchedules=(ScheduleID="Covert_Escape_CI_Lost", \\
 				  ExcludeTacticalTag="DisableStandardSchedules", \\
+                  IncludeTacticalTag="SITREP_TheLost", \\
 				  DefaultEncounterLeaderSpawnList = "NoHardCCUnits_Followers", \\
 				  DefaultEncounterFollowerSpawnList = "NoHardCCUnits_Followers", \\
 				  XComSquadStartsConcealed=false, \\
@@ -14,4 +15,22 @@
 				  PrePlacedEncounters[0]=(EncounterID="OPNx1_Pathetic", EncounterZoneOffsetAlongLOP=-10.0, EncounterZoneWidth=36.0, EncounterZoneDepthOverride=8.0), \\
 				  PrePlacedEncounters[1]=(EncounterID="OPNx1_Pathetic", EncounterZoneOffsetAlongLOP=10.0, EncounterZoneWidth=36.0, EncounterZoneDepthOverride=8.0), \\
 				  PrePlacedEncounters[2]=(EncounterID="OPNx1_Pathetic", EncounterZoneOffsetAlongLOP=30.0, EncounterZoneWidth=36.0, EncounterZoneDepthOverride=8.0), \\
+				  )
+
++MissionSchedules=(ScheduleID="Covert_Escape_CI", \\
+				  ExcludeTacticalTag="SITREP_TheLost", \\
+				  DefaultEncounterLeaderSpawnList = "NoHardCCUnits_Followers", \\
+				  DefaultEncounterFollowerSpawnList = "NoHardCCUnits_Followers", \\
+				  XComSquadStartsConcealed=false, \\
+				  MinRequiredAlertLevel=1, MaxRequiredAlertLevel=7, \\
+				  IdealXComSpawnDistance=80, \\
+				  MinXComSpawnDistance=40, \\
+				  EncounterZonePatrolDepth=4.0, \\
+				  PrePlacedEncounters[0]=(EncounterID="OPNx1_Pathetic", EncounterZoneOffsetAlongLOP=-10.0, EncounterZoneWidth=36.0, EncounterZoneDepthOverride=5.0), \\
+				  PrePlacedEncounters[1]=(EncounterID="OPNx1_Pathetic", EncounterZoneOffsetAlongLOP=-5.0, EncounterZoneWidth=36.0, EncounterZoneDepthOverride=5.0), \\
+				  PrePlacedEncounters[2]=(EncounterID="OPNx1_Pathetic", EncounterZoneOffsetAlongLOP=5.0, EncounterZoneWidth=36.0, EncounterZoneDepthOverride=5.0), \\
+				  PrePlacedEncounters[3]=(EncounterID="OPNx1_Pathetic", EncounterZoneOffsetAlongLOP=15.0, EncounterZoneWidth=36.0, EncounterZoneDepthOverride=5.0), \\
+				  PrePlacedEncounters[4]=(EncounterID="OPNx1_Pathetic", EncounterZoneOffsetAlongLOP=30.0, EncounterZoneWidth=36.0, EncounterZoneDepthOverride=5.0), \\
+				  PrePlacedEncounters[5]=(EncounterID="OPNx1_Pathetic", EncounterZoneOffsetAlongLOP=40.0, EncounterZoneWidth=36.0, EncounterZoneDepthOverride=5.0), \\
+                  MaxTurrets=0, \\
 				  )


### PR DESCRIPTION
I've tried to make a schedule for ambush missions when no lost are present - and it worked - but it also gets used for ambushes that do have lost for some reason - even despite `ExcludeTacticalTag="SITREP_TheLost"`

@ChrisTheThinMint you wanted to make the schedule - here you go 😂 Also, turns out I suck at this, so you can probably improve my new schedule as well - it didn't really do what I expected it to