### PR TITLE
Make setup of infil missions more configurable

### DIFF
--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2CovertMissionInfoTemplate.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2CovertMissionInfoTemplate.uc
@@ -10,6 +10,9 @@ class X2CovertMissionInfoTemplate extends X2DataTemplate;
 
 var array<name> MissionRewards;
 var name MissionSource;
+var Delegate<InitInfilDelegate> InitMissionFn;
+
+delegate InitInfilDelegate(XComGameState NewGameState, XComGameState_CovertAction Action, XComGameState_MissionSiteInfiltration MissionSite);
 
 defaultproperties
 {

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/XComGameState_MissionSiteInfiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/XComGameState_MissionSiteInfiltration.uc
@@ -21,35 +21,11 @@ function SetupFromAction(XComGameState NewGameState, XComGameState_CovertAction 
 {
 	local X2CovertMissionInfoTemplateManager InfilMgr;
 	local X2CovertMissionInfoTemplate MissionInfo;
-	local XComGameState_Reward RewardState, ActionReward;
-	local array<X2RewardTemplate> RewardTemplates;
-	local X2MissionSourceTemplate MissionSource;
-	local array<XComGameState_Reward> MissionRewards;
-	local Vector2D MissionLocation;
-	local int i;
 
 	InfilMgr = class'X2CovertMissionInfoTemplateManager'.static.GetCovertMissionInfoTemplateManager();
 	MissionInfo = InfilMgr.GetCovertMissionInfoTemplateFromCA(Action.GetMyTemplateName());
-	RewardTemplates = class'X2Helper_Infiltration'.static.GetCovertMissionRewards(MissionInfo);
-	MissionSource = class'X2Helper_Infiltration'.static.GetCovertMissionSource(MissionInfo);
-	
-	for (i = 0; i < RewardTemplates.length; i++)
-	{
-		RewardState = RewardTemplates[i].CreateInstanceFromTemplate(NewGameState);
-		MissionRewards.AddItem(RewardState);
-	}
 
-	ActionReward = XComGameState_Reward(`XCOMHISTORY.GetGameStateForObjectID(Action.RewardRefs[0].ObjectID));
-	if(ActionReward.GetMyTemplateName() == 'ActionReward_P2DarkEvent')
-		DarkEvent = ActionReward.RewardObjectReference;
-
-	// Set the location - required for camera pan to work properly
-	MissionLocation.X = Action.Location.X;
-	MissionLocation.Y = Action.Location.Y;
-
-	// TODO: Region is messed up
-	//ResistanceFaction = Faction;
-	BuildMission(MissionSource, MissionLocation, Region, MissionRewards, true);
+	MissionInfo.InitMissionFn(NewGameState, Action, self);
 	SetSoldiersFromAction(Action);
 }
 


### PR DESCRIPTION
Move most of the logic over to X2CovertMissionInfo delegates that are customizable on a per-case basis. Also should fix #104 and #105 