### PR TITLE
Activate narrative objectives after completing first chain

### DIFF
--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2DownloadableContentInfo_CovertInfiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2DownloadableContentInfo_CovertInfiltration.uc
@@ -139,6 +139,7 @@ static event OnPostTemplatesCreated()
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchTLPArmorsets();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchTLPWeapons();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchWeaponTechs();
+	class'X2Helper_Infiltration_TemplateMod'.static.ReplaceNarrativeStartObjectives();
 
 	// These aren't actually template changes, but's this is still a convenient place to do it - before the game fully loads
 	MarkPlotsForCovertEscape();

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
@@ -553,7 +553,7 @@ static function ReplaceNarrativeStartObjectives()
 	}
 	else
 	{
-		Template.CompletionEvent = 'CI_ChainComplete';
+		Template.CompletionEvent = 'ActivityChainEnded';
 	}
 	
 	Template = X2ObjectiveTemplate(TemplateManager.FindStrategyElementTemplate('T2_M0_L0_BlacksiteReveal'));
@@ -563,7 +563,7 @@ static function ReplaceNarrativeStartObjectives()
 	}
 	else
 	{
-		Template.CompletionEvent = 'CI_ChainComplete';
+		Template.CompletionEvent = 'ActivityChainEnded';
 	}
 	
 	Template = X2ObjectiveTemplate(TemplateManager.FindStrategyElementTemplate('XP0_M5_ActivateChosenLostAndAbandoned'));
@@ -573,7 +573,7 @@ static function ReplaceNarrativeStartObjectives()
 	}
 	else
 	{
-		Template.CompletionEvent = 'CI_ChainComplete';
+		Template.CompletionEvent = 'ActivityChainEnded';
 	}
 }
 

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
@@ -539,6 +539,44 @@ static function RemoveNoCovertActionNags()
 	}
 }
 
+static function ReplaceNarrativeStartObjectives()
+{
+	local X2StrategyElementTemplateManager TemplateManager;
+	local X2ObjectiveTemplate Template;
+
+	TemplateManager = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
+	
+	Template = X2ObjectiveTemplate(TemplateManager.FindStrategyElementTemplate('T2_M0_CompleteGuerillaOps'));
+	if (Template == none)
+	{
+		`REDSCREEN("CI: Failed to find T2_M0_CompleteGuerillaOps template");
+	}
+	else
+	{
+		Template.CompletionEvent = 'CI_ChainComplete';
+	}
+	
+	Template = X2ObjectiveTemplate(TemplateManager.FindStrategyElementTemplate('T2_M0_L0_BlacksiteReveal'));
+	if (Template == none)
+	{
+		`REDSCREEN("CI: Failed to find T2_M0_L0_BlacksiteReveal template");
+	}
+	else
+	{
+		Template.CompletionEvent = 'CI_ChainComplete';
+	}
+	
+	Template = X2ObjectiveTemplate(TemplateManager.FindStrategyElementTemplate('XP0_M5_ActivateChosenLostAndAbandoned'));
+	if (Template == none)
+	{
+		`REDSCREEN("CI: Failed to find XP0_M5_ActivateChosenLostAndAbandoned template");
+	}
+	else
+	{
+		Template.CompletionEvent = 'CI_ChainComplete';
+	}
+}
+
 //////////////////
 /// Facilities ///
 //////////////////

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/XComGameState_ActivityChain.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/XComGameState_ActivityChain.uc
@@ -219,7 +219,7 @@ function CurrentStageHasCompleted (XComGameState NewGameState)
 			m_Template.CleanupChain(NewGameState, self);
 		}
 
-		`XEVENTMGR.TriggerEvent('CI_ChainComplete', , , NewGameState);
+		`XEVENTMGR.TriggerEvent('ActivityChainEnded', self, self, NewGameState);
 	}
 
 	`CI_Trace("Finished handling stage completion");

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/XComGameState_ActivityChain.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/XComGameState_ActivityChain.uc
@@ -219,7 +219,7 @@ function CurrentStageHasCompleted (XComGameState NewGameState)
 			m_Template.CleanupChain(NewGameState, self);
 		}
 
-		`XEVENTMGR.TriggerEvent('GuerillaOpComplete', , , NewGameState);
+		`XEVENTMGR.TriggerEvent('CI_ChainComplete', , , NewGameState);
 	}
 
 	`CI_Trace("Finished handling stage completion");

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/XComGameState_ActivityChain.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/XComGameState_ActivityChain.uc
@@ -218,6 +218,8 @@ function CurrentStageHasCompleted (XComGameState NewGameState)
 		{
 			m_Template.CleanupChain(NewGameState, self);
 		}
+
+		`XEVENTMGR.TriggerEvent('GuerillaOpComplete', , , NewGameState);
 	}
 
 	`CI_Trace("Finished handling stage completion");


### PR DESCRIPTION
Narrative objectives that activate the Blacksite and the Chosen are stuck waiting for notice of Guerilla Op completion, which doesn't exist here. Change that so they trigger when the player completes their first chain, win or lose.