### PR TITLE
Create dummy rewards so all activities have reward localization

### DIFF
--- a/CovertInfiltration/Localization/XComGame.int
+++ b/CovertInfiltration/Localization/XComGame.int
@@ -264,4 +264,16 @@ Summary="Increases Barracks capacity by 10, allowing more soldiers to be maintai
 [LivingQuarters_BarracksSizeII X2FacilityUpgradeTemplate]
 DisplayName="Barracks Size II"
 FacilityName="Living Quarters"
-Summary="Increases Barracks capacity by a further 15 without increasing recovery times."
+Summary="Increases Barracks capacity by a further 15, allowing more soldiers to be maintained without an increase to recovery times."
+
+[Reward_Rumor X2RewardTemplate]
+DisplayName="Resistance Rumor"
+RewardDetails="Reveal a Point of Interest on the Geoscape"
+
+[Reward_Materiel X2RewardTemplate]
+DisplayName="Enemy Materiel"
+RewardDetails="Recover alien materials and supplies"
+
+[Reward_Progress X2RewardTemplate]
+DisplayName="Advance Chain"
+RewardDetails="Unlock the next mission in the chain"

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
@@ -536,11 +536,9 @@ static function PatchQuestItems ()
 				QuestItemTemplate.MissionSource.AddItem('MissionSource_RecoverFlightDevice');
 			}
 
-			// This will allow non-DE (the DE ones don't use reward filtering) quest items to be picked for our missions
-			// Note that implementation of #254 will likely break this "fix", so we will need to revist it then
 			if (QuestItemTemplate.RewardType.Length > 0)
 			{
-				QuestItemTemplate.RewardType.AddItem('Reward_None');
+				QuestItemTemplate.RewardType.AddItem('Reward_Rumor');
 			}
 		}
 	}

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2StrategyElement_DefaultActivities.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2StrategyElement_DefaultActivities.uc
@@ -58,7 +58,7 @@ static function CreateRecoverPersonnel (out array<X2DataTemplate> Templates)
 	Activity = CreateStandardInfilActivity(CovertAction, "RecoverPersonnel", "ResOps", "img:///UILibrary_XPACK_Common.MissionIcon_ResOps");
 
 	Activity.OnSuccess = OnSuccessPOI;
-	Activity.MissionRewards.AddItem('Reward_None');
+	Activity.MissionRewards.AddItem('Reward_Rumor');
 	Activity.GetMissionDifficulty = GetMissionDifficultyFromMonth;
 	Activity.WasMissionSuccessful = class'X2StrategyElement_DefaultMissionSources'.static.OneStrategyObjectiveCompleted;
 	
@@ -109,7 +109,7 @@ static function CreateRecoverInformant (out array<X2DataTemplate> Templates)
 	Activity = CreateStandardInfilActivity(CovertAction, "RecoverInformant", "ResOps", "img:///UILibrary_XPACK_Common.MissionIcon_ResOps");
 
 	Activity.OnSuccess = OnSuccessPOI;
-	Activity.MissionRewards.AddItem('Reward_None');
+	Activity.MissionRewards.AddItem('Reward_Rumor');
 	Activity.GetMissionDifficulty = GetMissionDifficultyFromMonth;
 	Activity.WasMissionSuccessful = class'X2StrategyElement_DefaultMissionSources'.static.OneStrategyObjectiveCompleted;
 	
@@ -172,7 +172,7 @@ static function CreatePrepareCounterDE (out array<X2DataTemplate> Templates)
 	CovertAction.OptionalCosts.AddItem(CreateOptionalCostSlot('Supplies', 25));
 
 	CovertAction.Risks.AddItem('CovertActionRisk_SoldierWounded');
-	CovertAction.Rewards.AddItem('Reward_None');
+	CovertAction.Rewards.AddItem('Reward_Progress');
 
 	Activity.CovertActionName = CovertAction.DataName;
 
@@ -189,7 +189,7 @@ static function CreateCounterDarkEvent (out array<X2DataTemplate> Templates)
 	Activity = CreateStandardInfilActivity(CovertAction, "CounterDarkEvent", "Retribution", "img:///UILibrary_XPACK_Common.MissionIcon_Retribution");
 
 	Activity.OnSuccess = OnSuccessPOI;
-	Activity.MissionRewards.AddItem('Reward_None');
+	Activity.MissionRewards.AddItem('Reward_Rumor');
 	Activity.GetMissionDifficulty = GetMissionDifficultyFromMonth;
 	Activity.WasMissionSuccessful = class'X2StrategyElement_DefaultMissionSources'.static.OneStrategyObjectiveCompleted;
 	
@@ -210,7 +210,7 @@ static function CreatePrepareFactionJB (out array<X2DataTemplate> Templates)
 
 	CovertAction.Slots.AddItem(CreateDefaultSoldierSlot('CovertActionSoldierStaffSlot', 3));
 	CovertAction.Slots.AddItem(CreateDefaultSoldierSlot('CovertActionSoldierStaffSlot'));
-	CovertAction.Rewards.AddItem('Reward_None');
+	CovertAction.Rewards.AddItem('Reward_Progress');
 
 	Activity.CovertActionName = CovertAction.DataName;
 
@@ -278,7 +278,7 @@ static function CreateRecoverUFO (out array<X2DataTemplate> Templates)
 	Activity = CreateStandardInfilActivity(CovertAction, "RecoverUFO", "ResOps", "img:///UILibrary_XPACK_Common.MissionIcon_ResOps");
 
 	Activity.OnSuccess = OnSuccessPOI;
-	Activity.MissionRewards.AddItem('Reward_None');
+	Activity.MissionRewards.AddItem('Reward_Rumor');
 	Activity.GetMissionDifficulty = GetMissionDifficultyFromMonth;
 	Activity.WasMissionSuccessful = class'X2StrategyElement_DefaultMissionSources'.static.OneStrategyObjectiveCompleted;
 	
@@ -301,7 +301,7 @@ static function CreatePrepareUFO (out array<X2DataTemplate> Templates)
 	CovertAction.Slots.AddItem(CreateDefaultSoldierSlot('CovertActionSoldierStaffSlot'));
 	CovertAction.Risks.AddItem('CovertActionRisk_SoldierCaptured');
 	CovertAction.Risks.AddItem('CovertActionRisk_SoldierWounded');
-	CovertAction.Rewards.AddItem('Reward_None');
+	CovertAction.Rewards.AddItem('Reward_Progress');
 
 	Activity.CovertActionName = CovertAction.DataName;
 
@@ -320,7 +320,7 @@ static function CreateLandedUFO (out array<X2DataTemplate> Templates)
 	Activity.ScreenClass = class'UIMission_LandedUFO';
 	Activity.MissionImage = "img:///UILibrary_StrategyImages.X2StrategyMap.Alert_UFO_Landed";
 	
-	Activity.MissionRewards.AddItem('Reward_None');
+	Activity.MissionRewards.AddItem('Reward_Materiel');
 	Activity.GetMissionDifficulty = GetMissionDifficultyFromMonth;
 	Activity.WasMissionSuccessful = class'X2StrategyElement_DefaultMissionSources'.static.OneStrategyObjectiveCompleted;
 
@@ -336,7 +336,7 @@ static function CreateCommanderSupply (out array<X2DataTemplate> Templates)
 	Activity = CreateStandardInfilActivity(CovertAction, "CommanderSupply", "GorillaOps", "img:///UILibrary_StrategyImages.X2StrategyMap.MissionIcon_GOPS");
 
 	Activity.OnSuccess = OnSuccessPOI;
-	Activity.MissionRewards.AddItem('Reward_None');
+	Activity.MissionRewards.AddItem('Reward_Rumor');
 	Activity.GetMissionDifficulty = GetMissionDifficultyFromMonth;
 	Activity.WasMissionSuccessful = class'X2StrategyElement_DefaultMissionSources'.static.OneStrategyObjectiveCompleted;
 	
@@ -352,7 +352,7 @@ static function CreateSupplyRaid (out array<X2DataTemplate> Templates)
 	CovertAction = class'X2StrategyElement_InfiltrationActions'.static.CreateInfiltrationTemplate(name("CovertAction_SupplyRaidInfil"), true);
 	Activity = CreateStandardInfilActivity(CovertAction, "SupplyRaid", "SupplyRaid_AdvConvoy", "img:///UILibrary_StrategyImages.X2StrategyMap.MissionIcon_SupplyRaid");
 
-	Activity.MissionRewards.AddItem('Reward_None');
+	Activity.MissionRewards.AddItem('Reward_Materiel');
 	Activity.GetMissionDifficulty = GetMissionDifficultyFromMonth;
 	Activity.WasMissionSuccessful = class'X2StrategyElement_DefaultMissionSources'.static.OneStrategyObjectiveCompleted;
 	
@@ -374,7 +374,7 @@ static function CreatePrepareFacility (out array<X2DataTemplate> Templates)
 	CovertAction.Slots.AddItem(CreateDefaultSoldierSlot('CovertActionSoldierStaffSlot'));
 	CovertAction.Slots.AddItem(CreateDefaultSoldierSlot('CovertActionSoldierStaffSlot'));
 	CovertAction.Risks.AddItem('CovertActionRisk_Ambush');
-	CovertAction.Rewards.AddItem('Reward_None');
+	CovertAction.Rewards.AddItem('Reward_Progress');
 
 	Activity.CovertActionName = CovertAction.DataName;
 
@@ -429,7 +429,7 @@ static function CreateGatherSupplies (out array<X2DataTemplate> Templates)
 	Activity.ScreenClass = class'UIMission_LandedUFO';
 	Activity.MissionImage = "img:///UILibrary_XPACK_StrategyImages.CovertOp_Recover_X_Supplies";
 	
-	Activity.MissionRewards.AddItem('Reward_None');
+	Activity.MissionRewards.AddItem('Reward_Materiel');
 	Activity.GetMissionDifficulty = GetMissionDifficultyFromMonth;
 	Activity.WasMissionSuccessful = class'X2StrategyElement_DefaultMissionSources'.static.OneStrategyObjectiveCompleted;
 

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2StrategyElement_InfiltrationRewards.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2StrategyElement_InfiltrationRewards.uc
@@ -12,12 +12,46 @@ static function array<X2DataTemplate> CreateTemplates()
 {
 	local array<X2DataTemplate> Rewards;
 	
+	Rewards.AddItem(CreateRumorRewardTemplate());
+	Rewards.AddItem(CreateMaterielRewardTemplate());
+	Rewards.AddItem(CreateProgressRewardTemplate());
+	
 	Rewards.AddItem(CreateDatapadRewardTemplate());
 	Rewards.AddItem(CreateContainerRewardTemplate());
 
 	Rewards.AddItem(CreateInfiltrationActivityProxyReward());
 
 	return Rewards;
+}
+
+static function X2DataTemplate CreateRumorRewardTemplate()
+{
+	local X2RewardTemplate Template;
+
+	// This is a dummy reward, the Point of Interest is spawned using the mission complete code in DefaultActivities
+	`CREATE_X2Reward_TEMPLATE(Template, 'Reward_Rumor');
+
+	return Template;
+}
+
+static function X2DataTemplate CreateMaterielRewardTemplate()
+{
+	local X2RewardTemplate Template;
+
+	// This is a dummy reward, the resources are in the mission's crates not the X2Reward
+	`CREATE_X2Reward_TEMPLATE(Template, 'Reward_Materiel');
+
+	return Template;
+}
+
+static function X2DataTemplate CreateProgressRewardTemplate()
+{
+	local X2RewardTemplate Template;
+
+	// This is a dummy reward, does nothing
+	`CREATE_X2Reward_TEMPLATE(Template, 'Reward_Progress');
+
+	return Template;
 }
 
 static function X2DataTemplate CreateDatapadRewardTemplate()


### PR DESCRIPTION
No activity should have Reward_None. Now they will have Reward_Rumor if they spawn a POI, Reward_Materiel if they have resource crates, or Reward_Progress if they grant nothing.

Closes #254 