### PR TITLE
Hide the sitreps panel for ambush mission when there are no sitreps

### DIFF
--- a/CovertInfiltration/Config/XComGameBoard.ini
+++ b/CovertInfiltration/Config/XComGameBoard.ini
@@ -100,5 +100,9 @@ ActionImage = "img:///UILibrary_XPACK_StrategyImages.DarkEvent_UFO"
 +MinChanceToOccur=25
 +MaxChanceToOccur=75
 
+[CovertActionRisk_Ambush X2CovertActionRiskTemplate]
+MinChanceToOccur=98
+MaxChanceToOccur=99
+
 [CovertInfiltration.X2EventListener_Infiltration]
 +CovertActionsPreventRandomSpawn=CovertAction_RecruitExtraFactionSoldier

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UIListener_Mission.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UIListener_Mission.uc
@@ -9,6 +9,7 @@ event OnInit (UIScreen Screen)
 
 	SpawnViewChainButton(MissionScreen);
 	CleanUpStrategyHudAlert(MissionScreen);
+	FixAmbushEmptySitreps(MissionScreen);
 }
 
 simulated protected function SpawnViewChainButton (UIMission MissionScreen)
@@ -112,4 +113,29 @@ simulated protected function CleanUpStrategyHudAlert (UIMission MissionScreen)
 			}
 		}
 	}
+}
+
+protected function FixAmbushEmptySitreps (UIMission Screen)
+{
+	local UIMission_ChosenAmbush AmbushScreen;
+
+	AmbushScreen = UIMission_ChosenAmbush(Screen);
+	if (AmbushScreen == none) return;
+
+	if (AmbushScreen.GetMission().GeneratedMission.SitReps.Length == 0)
+	{
+		AmbushScreen.SetTimer(1.0, false, nameof(HideSitRepPanel), self);
+	}
+}
+
+static protected function HideSitRepPanel ()
+{
+	local UIScreenStack ScreenStack;
+	local UIMission MissionScreen;
+
+	ScreenStack = `SCREENSTACK;
+	MissionScreen = UIMission(ScreenStack.GetFirstInstanceOf(class'UIMission'));
+
+	// Neither Hide nor Remove helps. Something's wierd on the flash side
+	MissionScreen.SitrepPanel.Remove();
 }


### PR DESCRIPTION
Closes #303 

Log from `Remove` attempt:

```
[0061.83] uicore: CachePanel Index=206, bRecycled?=1, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen
[0061.83] uicore: CachePanel Index=786, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238
[0061.83] uicore: CachePanel Index=787, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ConfirmButton
[0061.83] uicore: CachePanel Index=788, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ButtonGroup
[0061.83] uicore: CachePanel Index=789, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ButtonGroup.Button0
[0061.83] uicore: CachePanel Index=790, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ButtonGroup.Button1
[0061.83] uicore: CachePanel Index=791, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.UIAlertShadowChamberPanel
[0061.83] uicore: CachePanel Index=792, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.SitRep
[0061.83] uicore: CachePanel Index=793, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.SitRep.SitRepInfoButton
[0061.83] uicore: CachePanel Index=794, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.SitRep.UIGamepadIcons_3
[0061.83] uicore: CachePanel Index=795, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.UIPanel_240
[0061.83] ScriptLog: SetCameraState: XComCamState_Earth_7 XComCamState_Earth 0.7500 False      23.6003
[0061.84] uicore: CachePanel Index=796, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241
[0061.84] uicore: CachePanel Index=797, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ConfirmButton
[0061.84] uicore: CachePanel Index=798, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ButtonGroup
[0061.84] uicore: CachePanel Index=799, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ButtonGroup.Button0
[0061.84] uicore: CachePanel Index=800, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ButtonGroup.Button1
[0061.84] uicore: CachePanel Index=801, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.UIAlertShadowChamberPanel
[0061.84] uicore: CachePanel Index=802, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.SitRep
[0061.84] uicore: CachePanel Index=803, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.SitRep.SitRepInfoButton
[0061.85] uicore: CachePanel Index=804, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.SitRep.UIGamepadIcons_4
[0061.85] uicore: CachePanel Index=805, bRecycled?=0, MCPath=_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.UIPanel_243
[0061.85] ScriptWarning: Control reached the end of non-void function (make certain that all paths through the function 'return <value>'
        X2DownloadableContentInfo_DLC_Day60 DLC_2.Default__X2DownloadableContentInfo_DLC_Day60
        Function DLC_2.X2DownloadableContentInfo_DLC_Day60:ShouldUpdateMissionSpawningInfo:0096
[0061.85] uicore: LoadScreen(): UIMission_ChosenAmbush_0 / package/gfxAlerts/Alerts
[0061.85] uicore: UIScreenStack::Pop 'UIAlert_0' - found at Index 1.
[0061.85] uicore: Removing Screen '_level0.theInterfaceMgr.UIAlert_0.theScreen'.
[0061.86] uicore: UIScreenStack::Pop 'UIMouseGuard_1' - found at Index 1.
[0061.86] uicore: Removing Screen '_level0.theInterfaceMgr.UIMouseGuard_1.MouseGuardMC'.
[0061.86] uicore: Clearing RemovalCache[0]:  781
[0061.86] uicore: Clearing RemovalCache[1]:  782
[0061.86] uicore: Clearing RemovalCache[2]:  783
[0061.86] uicore: Clearing RemovalCache[3]:  784
[0061.86] uicore: Clearing RemovalCache[4]:  785
[0061.87] uicore: Clearing RemovalCache[5]:  780
[0061.91] DevGFxUI: GFX opened 'file': / package/gfxalerts/alerts
[0061.91] DevGFxUI: GFX opened 'file': / package/gfxstrategycomponents/strategycomponents.gfx
[0061.95] uicore: Invoke: _level0.theInterfaceMgr.UINarrativeCommLink_2.theCommLink.AnchorToTopRightNoBuffer
[0061.95] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen
[0061.95] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.ForceExportInstance.instance6730' wasn't handled, calling Show()
[0061.96] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.ForceExportInstance.instance6730.SitRepContainer' wasn't handled, calling Show()
[0061.96] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.ForceExportInstance.instance6730.SitRepInfoButton' wasn't handled, calling Show()
[0061.96] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.ForceExportInstance.instance6731' wasn't handled, calling Show()
[0061.96] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.ForceExportInstance.instance6731.ShadowChamberEnemyList' wasn't handled, calling Show()
[0061.96] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.ForceExportInstance.instance6742' wasn't handled, calling Show()
[0061.96] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.ForceExportInstance.instance6742.logo.ChosenSymbol' wasn't handled, calling Show()
[0061.98] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238
[0061.98] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.instance6759' wasn't handled, calling Show()
[0061.98] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.chosenIcon.ChosenSymbol' wasn't handled, calling Show()
[0061.99] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.bladeHeaderMC' wasn't handled, calling Show()
[0061.99] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.bladeObjectiveListMC' wasn't handled, calling Show()
[0061.99] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.bladeImageMC' wasn't handled, calling Show()
[0061.99] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ButtonGroup
[0061.99] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ButtonGroup.Button0
[0061.99] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ButtonGroup.Button0.theButton' wasn't handled, calling Show()
[0061.99] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ButtonGroup.Button0.buttonHelpIcon.theIcon' wasn't handled, calling Show()
[0062.00] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ButtonGroup.Button1
[0062.00] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ButtonGroup.Button1.theButton' wasn't handled, calling Show()
[0062.00] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ButtonGroup.Button1.buttonHelpIcon.theIcon' wasn't handled, calling Show()
[0062.00] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.lockedMC' wasn't handled, calling Show()
[0062.00] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.lockedMC.ConfirmButton' wasn't handled, calling Show()
[0062.00] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.lockedMC.ConfirmButton.theButton' wasn't handled, calling Show()
[0062.00] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.lockedMC.ConfirmButton.buttonHelpIcon.theIcon' wasn't handled, calling Show()
[0062.00] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.lockedMC.lockedMessage' wasn't handled, calling Show()
[0062.01] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ShadowChamber' wasn't handled, calling Show()
[0062.01] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ShadowChamber.ShadowChamberEnemyList' wasn't handled, calling Show()
[0062.01] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241
[0062.01] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.instance6790' wasn't handled, calling Show()
[0062.01] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.chosenIcon.ChosenSymbol' wasn't handled, calling Show()
[0062.01] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.bladeHeaderMC' wasn't handled, calling Show()
[0062.01] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.bladeObjectiveListMC' wasn't handled, calling Show()
[0062.01] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.bladeImageMC' wasn't handled, calling Show()
[0062.01] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ButtonGroup
[0062.01] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ButtonGroup.Button0
[0062.01] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ButtonGroup.Button0.theButton' wasn't handled, calling Show()
[0062.01] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ButtonGroup.Button0.buttonHelpIcon.theIcon' wasn't handled, calling Show()
[0062.01] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ButtonGroup.Button1
[0062.02] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ButtonGroup.Button1.theButton' wasn't handled, calling Show()
[0062.02] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ButtonGroup.Button1.buttonHelpIcon.theIcon' wasn't handled, calling Show()
[0062.02] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.lockedMC' wasn't handled, calling Show()
[0062.02] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.lockedMC.ConfirmButton' wasn't handled, calling Show()
[0062.02] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.lockedMC.ConfirmButton.theButton' wasn't handled, calling Show()
[0062.02] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.lockedMC.ConfirmButton.buttonHelpIcon.theIcon' wasn't handled, calling Show()
[0062.02] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.lockedMC.lockedMessage' wasn't handled, calling Show()
[0062.02] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ShadowChamber' wasn't handled, calling Show()
[0062.02] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ShadowChamber.ShadowChamberEnemyList' wasn't handled, calling Show()
[0062.05] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ConfirmButton
[0062.05] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ConfirmButton.theButton' wasn't handled, calling Show()
[0062.05] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.ConfirmButton.buttonHelpIcon.theIcon' wasn't handled, calling Show()
[0062.05] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.UIAlertShadowChamberPanel
[0062.05] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.UIAlertShadowChamberPanel.ShadowChamberEnemyList' wasn't handled, calling Show()
[0062.05] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.SitRep
[0062.05] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.SitRep.SitRepContainer' wasn't handled, calling Show()
[0062.05] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.SitRep.SitRepInfoButton
[0062.05] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.UIPanel_240
[0062.06] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.UIPanel_240.logo.ChosenSymbol' wasn't handled, calling Show()
[0062.06] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ConfirmButton
[0062.06] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ConfirmButton.theButton' wasn't handled, calling Show()
[0062.06] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.ConfirmButton.buttonHelpIcon.theIcon' wasn't handled, calling Show()
[0062.06] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.UIAlertShadowChamberPanel
[0062.06] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.UIAlertShadowChamberPanel.ShadowChamberEnemyList' wasn't handled, calling Show()
[0062.06] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.SitRep
[0062.06] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.SitRep.SitRepContainer' wasn't handled, calling Show()
[0062.07] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.SitRep.SitRepInfoButton
[0062.07] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.UIPanel_243
[0062.07] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.UIPanel_243.logo.ChosenSymbol' wasn't handled, calling Show()
[0062.07] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.chosenIcon.ChosenSymbol.image0' wasn't handled, calling Show()
[0062.07] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.chosenIcon.ChosenSymbol.image1' wasn't handled, calling Show()
[0062.07] uicore: FlashRaiseInit: '_level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.chosenIcon.ChosenSymbol.image2' wasn't handled, calling Show()
[0062.07] uicore: Flash raise command: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.SitRep.SitRepInfoButton, RealizeSize, 23.95,26.1
[0062.08] uicore: Flash raise command: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.SitRep.SitRepInfoButton, RealizeSize, 23.95,26.1
[0062.09] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_238.SitRep.UIGamepadIcons_3
[0062.09] uicore: FlashRaiseInit: _level0.theInterfaceMgr.UIMission_ChosenAmbush_0.theScreen.UIPanel_241.SitRep.UIGamepadIcons_4
[0062.56] uicore: Invoke: _level0.theInterfaceMgr.UINarrativeCommLink_2.theCommLink.AnchorToTopRightNoBuffer
[0062.78] uicore: Clearing RemovalCache[0]:  802
[0062.78] uicore: Clearing RemovalCache[1]:  803
[0062.78] uicore: Clearing RemovalCache[2]:  804
```