### PR TITLE
Disallow free promotion from spawning as a CA slot reward

### DIFF
--- a/CovertInfiltration/Config/XComGameData.ini
+++ b/CovertInfiltration/Config/XComGameData.ini
@@ -21,6 +21,9 @@ LiveFireTrainingRanksIncrease=2
 +arrPointsOfInterestToRemove="POI_HeavyWeapon"
 +arrPointsOfInterestToRemove="POI_GrenadeAmmo"
 
+; Soldier promotion rewards will be removed from all covert actions except those in this array
++arrAllowPromotionReward="CovertAction_ExhaustiveTraining"
+
 [XComGame.XComGameState_MissionCalendar]
 -MissionDecks[0]=(DeckName="StartMissions", NextDeckName="MidMissions", MissionMonthDays=65, bForceNoConsecutive=true,         Missions[0]=(MissionSource="MissionSource_GuerillaOp"),         Missions[1]=(MissionSource="MissionSource_ResistanceOp"),         Missions[2]=(MissionSource="MissionSource_Retaliation"),         Missions[3]=(MissionSource="MissionSource_GuerillaOp"),         Missions[4]=(MissionSource="MissionSource_SupplyRaid"),         Missions[5]=(MissionSource="MissionSource_ResistanceOp"),         Missions[6]=(MissionSource="MissionSource_GuerillaOp"),         Missions[7]=(MissionSource="MissionSource_Retaliation"),         Missions[8]=(MissionSource="Blank"))
 -MissionDecks[1]=(DeckName="MidMissions", NextDeckName="LateMissions", MissionMonthDays=65, bForceNoConsecutive=true,         Missions[0]=(MissionSource="MissionSource_GuerillaOp"),         Missions[1]=(MissionSource="MissionSource_SupplyRaid"),         Missions[2]=(MissionSource="MissionSource_Council"),         Missions[3]=(MissionSource="MissionSource_GuerillaOp"),         Missions[4]=(MissionSource="MissionSource_Retaliation"),         Missions[5]=(RandomDeckName="RandomMissions"),         Missions[6]=(MissionSource="MissionSource_GuerillaOp"),         Missions[7]=(RandomDeckName="RandomMissions"),         Missions[8]=(RandomDeckName="RandomMissions"))

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2DownloadableContentInfo_CovertInfiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2DownloadableContentInfo_CovertInfiltration.uc
@@ -308,6 +308,7 @@ static event OnPostTemplatesCreated()
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchItemStats();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchGuerillaTacticsSchool();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchAcademyStaffSlot();
+	class'X2Helper_Infiltration_TemplateMod'.static.PatchCovertActionPromotionRewards();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchTLPArmorsets();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchTLPWeapons();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchWeaponTechs();

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
@@ -37,6 +37,7 @@ var config(GameData) array<name> arrRemoveFactionCard;
 var config(GameData) int LiveFireTrainingRanksIncrease;
 var config(GameData) array<name> arrSabotagesToRemove;
 var config(GameData) array<name> arrPointsOfInterestToRemove;
+var config(GameData) array<name> arrAllowPromotionReward;
 
 var config(UI) bool SHOW_INFILTRATION_STATS;
 var config(UI) bool SHOW_DETERRENCE_STATS;
@@ -1084,7 +1085,7 @@ static function string GetPatchedHangarQueueMessage(StateObjectReference Facilit
 }
 
 ///////////////////
-/// Staff slots ///
+/// Staff Slots ///
 ///////////////////
 
 static function PatchAcademyStaffSlot ()
@@ -1198,6 +1199,35 @@ static protected function string GetAcademySlotBonusDisplayString (XComGameState
 	}
 
 	return class'X2StrategyElement_DefaultStaffSlots'.static.GetBonusDisplayString(SlotState, "%SKILL", Contribution);
+}
+
+static function PatchCovertActionPromotionRewards()
+{
+	local X2StrategyElementTemplateManager TemplateManager;
+	local X2DataTemplate DataTemplate;
+	local X2CovertActionTemplate ActionTemplate;
+	local int index;
+	
+	TemplateManager = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
+
+	foreach TemplateManager.IterateTemplates(DataTemplate)
+	{
+		ActionTemplate = X2CovertActionTemplate(DataTemplate);
+
+		if (ActionTemplate != none)
+		{
+			// Must be a for loop because a foreach loop is passed a copy of the array
+			for (index = 0; index < ActionTemplate.Slots.Length; index++)
+			{
+				if (ActionTemplate.Slots[index].StaffSlot == 'CovertActionSoldierStaffSlot'
+				 && default.arrAllowPromotionReward.Find(ActionTemplate.DataName) == INDEX_NONE)
+				{
+					`CI_Log("Patching " $ ActionTemplate.DataName);
+					ActionTemplate.Slots[index].Rewards.RemoveItem('Reward_RankUp');
+				}
+			}
+		}
+	}
 }
 
 /////////////////////

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
@@ -1222,7 +1222,6 @@ static function PatchCovertActionPromotionRewards()
 				if (ActionTemplate.Slots[index].StaffSlot == 'CovertActionSoldierStaffSlot'
 				 && default.arrAllowPromotionReward.Find(ActionTemplate.DataName) == INDEX_NONE)
 				{
-					`CI_Log("Patching " $ ActionTemplate.DataName);
 					ActionTemplate.Slots[index].Rewards.RemoveItem('Reward_RankUp');
 				}
 			}

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
@@ -1216,10 +1216,10 @@ static function PatchCovertActionPromotionRewards()
 
 		if (ActionTemplate != none)
 		{
-			// Must be a for loop because a foreach loop is passed a copy of the array
-			for (index = 0; index < ActionTemplate.Slots.Length; index++)
+			if (default.arrAllowPromotionReward.Find(ActionTemplate.DataName) == INDEX_NONE)
 			{
-				if (default.arrAllowPromotionReward.Find(ActionTemplate.DataName) == INDEX_NONE)
+				// Must be a for loop because a foreach loop is passed a copy of the array
+				for (index = 0; index < ActionTemplate.Slots.Length; index++)
 				{
 					ActionTemplate.Slots[index].Rewards.RemoveItem('Reward_RankUp');
 				}

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
@@ -1219,8 +1219,7 @@ static function PatchCovertActionPromotionRewards()
 			// Must be a for loop because a foreach loop is passed a copy of the array
 			for (index = 0; index < ActionTemplate.Slots.Length; index++)
 			{
-				if (ActionTemplate.Slots[index].StaffSlot == 'CovertActionSoldierStaffSlot'
-				 && default.arrAllowPromotionReward.Find(ActionTemplate.DataName) == INDEX_NONE)
+				if (default.arrAllowPromotionReward.Find(ActionTemplate.DataName) == INDEX_NONE)
 				{
 					ActionTemplate.Slots[index].Rewards.RemoveItem('Reward_RankUp');
 				}


### PR DESCRIPTION
The sole exception is our Exhaustive Training CA, the whole point of which is to spawn a free promotion.
Closes #429 