### PR TITLE
Change the proxy reward mechanism to support VIP units

### DIFF
--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2ActivityTemplate_Mission.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2ActivityTemplate_Mission.uc
@@ -105,10 +105,10 @@ static function StateObjectReference InitMissionReward (XComGameState NewGameSta
 	RewardState = RewardTemplate.CreateInstanceFromTemplate(NewGameState);
 	ResHQ = class'UIUtilities_Strategy'.static.GetResistanceHQ();
 	
-	// If this is a chain proxy reward, send the chain state reference into it instead of the region reference
+	// If this is a chain proxy reward, replace it with a reward from the chainwide reward pool
 	if (RewardState.GetMyTemplateName() == 'Reward_ChainProxy')
 	{
-		RewardState.GenerateReward(NewGameState,, ActivityState.GetActivityChain().GetReference());
+		RewardState = ActivityState.GetActivityChain().ClaimChainReward(NewGameState);
 	}
 	else
 	{

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2StrategyElement_InfiltrationRewards.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2StrategyElement_InfiltrationRewards.uc
@@ -513,14 +513,7 @@ static function DisplayProxyRewardPopup (XComGameState_Reward RewardState)
 
 static function GenerateProxyReward (XComGameState_Reward RewardState, XComGameState NewGameState, optional float RewardScalar = 1.0, optional StateObjectReference AuxRef)
 {
-	local XComGameState_ActivityChain ChainState;
-	local XComGameState_Reward ProxyRewardState;
-
-	ChainState = XComGameState_ActivityChain(NewGameState.ModifyStateObject(class'XComGameState_ActivityChain', AuxRef.ObjectID));
-	ProxyRewardState = ChainState.ClaimChainReward(NewGameState);
-
-	RewardState.RewardObjectReference = ProxyRewardState.GetReference();
-	RewardState.Quantity = ProxyRewardState.Quantity;
+	`REDSCREEN("Reward_ChainProxy was generated! This should never happen! This reward should not be used for any mission outside of an activity chain!");
 }
 
 static function XComGameState_Reward GetProxyReward (XComGameState_Reward RewardState)


### PR DESCRIPTION
What I've done is essentially instead of having the proxy reward contain a link to the actual reward, which doesn't fly with the VIP creation code, the proxy reward is completely replaced in the mission rewards list with the actual reward. This method spawns the correct VIP unit instead of resulting in the mission's default VIP unit being spawned.
Closes #530 