### PR TITLE
Improve Gatecrasher's narrative, enemies, and hack rewards

### DIFF
--- a/CovertInfiltration/Config/XComMissionDefs.ini
+++ b/CovertInfiltration/Config/XComMissionDefs.ini
@@ -84,15 +84,52 @@
 	bIsTacticalObjective=false, bIsStrategyObjective=false, bIsTriadObjective=false), \\
 	MissionObjectives[2]=(ObjectiveName="Prisoner_01", \\
 	bIsTacticalObjective=false, bIsStrategyObjective=false, bIsTriadObjective=false), \\
-	MissionSchedules[0]="SabotageCC_D1_Standard", \\
-	MissionSchedules[1]="SabotageCC_D2_Standard", \\
-	MissionSchedules[2]="SabotageCC_D3_Standard", \\
-	MissionSchedules[3]="SabotageCC_D4_Standard" \\
+	MissionSchedules[0]="GatecrasherCI_D1_Standard", \\
+	MissionSchedules[1]="GatecrasherCI_D2_Standard", \\
+	MissionSchedules[2]="GatecrasherCI_D3_Standard", \\
+	MissionSchedules[3]="GatecrasherCI_D4_Standard" \\
 	)
-	
-; XPAC Compound Rescue			   
+	   
 +arrObjectiveSpawnInfo=(sMissionType="GatecrasherCI", bUseObjectiveLocation=True, \\
                        iMinObjectives=2, iMaxObjectives=2, iMinTilesBetweenObjectives=0, \\
                        iMinTilesFromObjectiveCenter=0, iMaxTilesFromObjectiveCenter=10000, \\
                        bCanSpawnOutsideObjectiveParcel=False, bReplaceSwapActor=True, \\
 					   DefaultVIPTemplate="Soldier_VIP")
+
+;-----------------------------------------------------------------------------------------
+; Sabotage Monument
+;-----------------------------------------------------------------------------------------
+
+-arrMissions=(MissionName="SabotageAdventMonument", sType="SabotageCC", \\
+	MissionFamily="SabotageCC", \\
+	MapNames[0]="Obj_SabotageCC", \\
+	MapNames[1]="CIN_XP_SoldierPlantBomb", \\
+	MapNames[2]="CIN_XP_GatecrasherEndMatinees", \\
+	MapNames[3]="UMS_MissionCore", \\
+	RequiredPlotObjectiveTags[0]="SabotageCC", \\
+	RequiredParcelObjectiveTags[0]="SabotageCC", \\
+	MissionObjectives[0]=(ObjectiveName="Sweep", \\
+	bIsTacticalObjective=true, bIsStrategyObjective=true, bIsTriadObjective=true), \\
+	MissionSchedules[0]="SabotageCC_D1_Standard", \\
+	MissionSchedules[1]="SabotageCC_D2_Standard", \\
+	MissionSchedules[2]="SabotageCC_D3_Standard")
+	
++arrMissions=(MissionName="SabotageAdventMonument", sType="SabotageCC", \\
+	MissionFamily="SabotageCC", \\
+	MapNames[0]="Obj_SabotageCC", \\
+	MapNames[1]="CIN_XP_SoldierPlantBomb", \\
+	MapNames[2]="CIN_XP_GatecrasherEndMatinees", \\
+	MapNames[3]="UMS_MissionCore", \\
+	RequiredPlotObjectiveTags[0]="SabotageCC", \\
+	RequiredParcelObjectiveTags[0]="SabotageCC", \\
+	MissionObjectives[0]=(ObjectiveName="Sweep", \\
+	bIsTacticalObjective=true, bIsStrategyObjective=true, bIsTriadObjective=true), \\
+	MissionSchedules[0]="Guerilla_D1_Standard", \\
+	MissionSchedules[1]="Guerilla_D2_Standard", \\
+	MissionSchedules[2]="Guerilla_D3_Standard", \\
+	MissionSchedules[3]="Guerilla_D4_Standard", \\
+	MissionSchedules[4]="Guerilla_D5_Standard", \\
+	MissionSchedules[5]="Guerilla_D6_Standard", \\
+	MissionSchedules[6]="Guerilla_D7_Standard", \\
+	MissionSchedules[7]="Guerilla_DX_Horde")
+	

--- a/CovertInfiltration/Config/XComSchedules.ini
+++ b/CovertInfiltration/Config/XComSchedules.ini
@@ -39,9 +39,28 @@
 ;;; Gatecrasher ;;;
 ;;;;;;;;;;;;;;;;;;;
 
-; Make SabotageCC_D3_Standard only for AL 3
-; Replace the 3 troopers pod with officer + 2 troopers
+; Remove old encounters
 
+-MissionSchedules=(ScheduleID="SabotageCC_D1_Standard", \\
+				  ExcludeTacticalTag="DisableStandardSchedules", \\
+				  IdealXComSpawnDistance=28, \\
+				  MinXComSpawnDistance=24, \\
+				  EncounterZonePatrolDepth=8.0, \\
+				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Patrolx2", EncounterZoneOffsetAlongLOP=3.0, EncounterZoneWidth=26.0), \\
+				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=20.0), \\
+				  MinRequiredAlertLevel=1, \\
+				  MaxRequiredAlertLevel=1)
+				  
+-MissionSchedules=(ScheduleID="SabotageCC_D2_Standard", \\
+				  ExcludeTacticalTag="DisableStandardSchedules", \\
+				  IdealXComSpawnDistance=28, \\
+				  MinXComSpawnDistance=24, \\
+				  EncounterZonePatrolDepth=8.0, \\
+				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Patrolx3", EncounterZoneOffsetAlongLOP=3.0, EncounterZoneWidth=26.0), \\
+				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=20.0), \\
+				  MinRequiredAlertLevel=2, \\
+				  MaxRequiredAlertLevel=2)
+				  
 -MissionSchedules=(ScheduleID="SabotageCC_D3_Standard", \\
 				  ExcludeTacticalTag="DisableStandardSchedules", \\
 				  IdealXComSpawnDistance=28, \\
@@ -53,27 +72,47 @@
 				  MinRequiredAlertLevel=3, \\
 				  MaxRequiredAlertLevel=1000)
 
-+MissionSchedules=(ScheduleID="SabotageCC_D3_Standard", \\
+; Replace with new encounters
+
++MissionSchedules=(ScheduleID="SabotageCC_D1_Standard", \\
 				  ExcludeTacticalTag="DisableStandardSchedules", \\
 				  IdealXComSpawnDistance=28, \\
 				  MinXComSpawnDistance=24, \\
 				  EncounterZonePatrolDepth=8.0, \\
-				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=3.0, EncounterZoneWidth=26.0), \\
-				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=20.0), \\
-				  PrePlacedEncounters[2]=(EncounterID="OPNx2_Weak", EncounterZoneOffsetAlongLOP=-24.0, EncounterZoneWidth=4.0, EncounterZoneOffsetFromLOP=-10.0, EncounterZoneDepthOverride=36.0), \\
+				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Patrolx2", EncounterZoneOffsetAlongLOP=18.0, EncounterZoneWidth=26.0), \\
+				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=6.0, EncounterZoneWidth=20.0), \\
+				  MinRequiredAlertLevel=1, \\
+				  MaxRequiredAlertLevel=1)
+				  
++MissionSchedules=(ScheduleID="SabotageCC_D2_Standard", \\
+				  ExcludeTacticalTag="DisableStandardSchedules", \\
+				  IdealXComSpawnDistance=28, \\
+				  MinXComSpawnDistance=24, \\
+				  EncounterZonePatrolDepth=8.0, \\
+				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Patrolx3", EncounterZoneOffsetAlongLOP=18.0, EncounterZoneWidth=26.0), \\
+				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=6.0, EncounterZoneWidth=20.0), \\
+				  MinRequiredAlertLevel=2, \\
+				  MaxRequiredAlertLevel=2)
+				  
++MissionSchedules=(ScheduleID="SabotageCC_D3_Standard", \\
+				  ExcludeTacticalTag="DisableStandardSchedules", \\
+				  IdealXComSpawnDistance=30, \\
+				  MinXComSpawnDistance=26, \\
+				  EncounterZonePatrolDepth=8.0, \\
+				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=-10.0, EncounterZoneWidth=14.0, EncounterZoneOffsetFromLOP=8.0), \\
+				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=24.0, EncounterZoneWidth=26.0), \\
+				  PrePlacedEncounters[2]=(EncounterID="OPNx2_Weak", EncounterZoneOffsetAlongLOP=6.0, EncounterZoneWidth=20.0), \\
 				  MinRequiredAlertLevel=3, \\
 				  MaxRequiredAlertLevel=3)
 
-; Add SabotageCC_D4_Standard
-
 +MissionSchedules=(ScheduleID="SabotageCC_D4_Standard", \\
 				  ExcludeTacticalTag="DisableStandardSchedules", \\
-				  IdealXComSpawnDistance=28, \\
-				  MinXComSpawnDistance=24, \\
+				  IdealXComSpawnDistance=30, \\
+				  MinXComSpawnDistance=26, \\
 				  EncounterZonePatrolDepth=8.0, \\
-				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Patrolx3", EncounterZoneOffsetAlongLOP=3.0, EncounterZoneWidth=26.0), \\
-				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=-2.0, EncounterZoneWidth=26.0, EncounterZoneOffsetFromLOP=7.0), \\
-				  PrePlacedEncounters[2]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=20.0), \\
-				  PrePlacedEncounters[3]=(EncounterID="OPNx2_Weak", EncounterZoneOffsetAlongLOP=-24.0, EncounterZoneWidth=4.0, EncounterZoneOffsetFromLOP=-10.0, EncounterZoneDepthOverride=36.0), \\
+				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=-10.0, EncounterZoneWidth=14.0, EncounterZoneOffsetFromLOP=8.0), \\
+				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=24.0, EncounterZoneWidth=26.0), \\
+				  PrePlacedEncounters[2]=(EncounterID="SabotageCC_Patrolx3", EncounterZoneOffsetAlongLOP=-16.0, EncounterZoneWidth=4.0, EncounterZoneOffsetFromLOP=-10.0, EncounterZoneDepthOverride=36.0), \\
+				  PrePlacedEncounters[3]=(EncounterID="OPNx2_Weak", EncounterZoneOffsetAlongLOP=6.0, EncounterZoneWidth=20.0), \\
 				  MinRequiredAlertLevel=4, \\
 				  MaxRequiredAlertLevel=1000)

--- a/CovertInfiltration/Config/XComSchedules.ini
+++ b/CovertInfiltration/Config/XComSchedules.ini
@@ -39,42 +39,7 @@
 ;;; Gatecrasher ;;;
 ;;;;;;;;;;;;;;;;;;;
 
-; Remove old encounters
-
--MissionSchedules=(ScheduleID="SabotageCC_D1_Standard", \\
-				  ExcludeTacticalTag="DisableStandardSchedules", \\
-				  IdealXComSpawnDistance=28, \\
-				  MinXComSpawnDistance=24, \\
-				  EncounterZonePatrolDepth=8.0, \\
-				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Patrolx2", EncounterZoneOffsetAlongLOP=3.0, EncounterZoneWidth=26.0), \\
-				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=20.0), \\
-				  MinRequiredAlertLevel=1, \\
-				  MaxRequiredAlertLevel=1)
-				  
--MissionSchedules=(ScheduleID="SabotageCC_D2_Standard", \\
-				  ExcludeTacticalTag="DisableStandardSchedules", \\
-				  IdealXComSpawnDistance=28, \\
-				  MinXComSpawnDistance=24, \\
-				  EncounterZonePatrolDepth=8.0, \\
-				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Patrolx3", EncounterZoneOffsetAlongLOP=3.0, EncounterZoneWidth=26.0), \\
-				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=20.0), \\
-				  MinRequiredAlertLevel=2, \\
-				  MaxRequiredAlertLevel=2)
-				  
--MissionSchedules=(ScheduleID="SabotageCC_D3_Standard", \\
-				  ExcludeTacticalTag="DisableStandardSchedules", \\
-				  IdealXComSpawnDistance=28, \\
-				  MinXComSpawnDistance=24, \\
-				  EncounterZonePatrolDepth=8.0, \\
-				  PrePlacedEncounters[0]=(EncounterID="SabotageCC_Patrolx3", EncounterZoneOffsetAlongLOP=3.0, EncounterZoneWidth=26.0), \\
-				  PrePlacedEncounters[1]=(EncounterID="SabotageCC_Guardx3", EncounterZoneOffsetAlongLOP=-11.0, EncounterZoneWidth=20.0), \\
-				  PrePlacedEncounters[2]=(EncounterID="OPNx2_Weak", EncounterZoneOffsetAlongLOP=-24.0, EncounterZoneWidth=4.0, EncounterZoneOffsetFromLOP=-10.0, EncounterZoneDepthOverride=36.0), \\
-				  MinRequiredAlertLevel=3, \\
-				  MaxRequiredAlertLevel=1000)
-
-; Replace with new encounters
-
-+MissionSchedules=(ScheduleID="SabotageCC_D1_Standard", \\
++MissionSchedules=(ScheduleID="GatecrasherCI_D1_Standard", \\
 				  ExcludeTacticalTag="DisableStandardSchedules", \\
 				  IdealXComSpawnDistance=28, \\
 				  MinXComSpawnDistance=24, \\
@@ -84,7 +49,7 @@
 				  MinRequiredAlertLevel=1, \\
 				  MaxRequiredAlertLevel=1)
 				  
-+MissionSchedules=(ScheduleID="SabotageCC_D2_Standard", \\
++MissionSchedules=(ScheduleID="GatecrasherCI_D2_Standard", \\
 				  ExcludeTacticalTag="DisableStandardSchedules", \\
 				  IdealXComSpawnDistance=28, \\
 				  MinXComSpawnDistance=24, \\
@@ -94,7 +59,7 @@
 				  MinRequiredAlertLevel=2, \\
 				  MaxRequiredAlertLevel=2)
 				  
-+MissionSchedules=(ScheduleID="SabotageCC_D3_Standard", \\
++MissionSchedules=(ScheduleID="GatecrasherCI_D3_Standard", \\
 				  ExcludeTacticalTag="DisableStandardSchedules", \\
 				  IdealXComSpawnDistance=30, \\
 				  MinXComSpawnDistance=26, \\
@@ -105,7 +70,7 @@
 				  MinRequiredAlertLevel=3, \\
 				  MaxRequiredAlertLevel=3)
 
-+MissionSchedules=(ScheduleID="SabotageCC_D4_Standard", \\
++MissionSchedules=(ScheduleID="GatecrasherCI_D4_Standard", \\
 				  ExcludeTacticalTag="DisableStandardSchedules", \\
 				  IdealXComSpawnDistance=30, \\
 				  MinXComSpawnDistance=26, \\

--- a/CovertInfiltration/Content/Maps/Missions/Obj_Gatecrasher_CI.umap
+++ b/CovertInfiltration/Content/Maps/Missions/Obj_Gatecrasher_CI.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1f312b1634e349db53435ff903294a1ff1153581f04f1eb32d220b13b06ca86e
-size 564512
+oid sha256:9b0bce4e854ceaa51e019f3fd5d9d4c4b5c918cda4a6484d67a888210007a14f
+size 564736

--- a/CovertInfiltration/Content/Maps/Missions/Obj_Gatecrasher_CI.umap
+++ b/CovertInfiltration/Content/Maps/Missions/Obj_Gatecrasher_CI.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1d7aa0bdf5c38207d7c4d5eaef85d03ff5c95ecfa5df650784008756a957c5fd
-size 569318
+oid sha256:1f312b1634e349db53435ff903294a1ff1153581f04f1eb32d220b13b06ca86e
+size 564512

--- a/CovertInfiltration/CovertInfiltration.x2proj
+++ b/CovertInfiltration/CovertInfiltration.x2proj
@@ -104,6 +104,9 @@
     <Content Include="Src\CovertInfiltration\Classes\ModConfigMenu_Defaults.uc">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Src\CovertInfiltration\Classes\SeqAct_ForceInteractiveObjectTacticalHack.uc">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Src\CovertInfiltration\Classes\SeqAct_GetAssociatedObjectiveObjects.uc">
       <SubType>Content</SubType>
     </Content>

--- a/CovertInfiltration/Localization/XComGame.int
+++ b/CovertInfiltration/Localization/XComGame.int
@@ -351,8 +351,8 @@ ConsoleObjectiveTextPools[0]=
 ConsoleObjectiveTextPools[1]=
 
 [GatecrasherCI X2MissionTemplate]
-DisplayName="Rescue VIPs from ADVENT Compound"
-Briefing="Rescue VIPs from ADVENT Compound"
+DisplayName="Operation Gatecrasher"
+Briefing="Break into ADVENT Compound and Rescue VIPs"
 PostMissionType="Operation Gatecrasher"
 BriefingImage="img:///UILibrary_Common.Xcom_default"
 ObjectiveTextPools[0]="Sweep the site and eliminate all hostiles"

--- a/CovertInfiltration/Localization/XComGame.int
+++ b/CovertInfiltration/Localization/XComGame.int
@@ -351,18 +351,14 @@ ConsoleObjectiveTextPools[0]=
 ConsoleObjectiveTextPools[1]=
 
 [GatecrasherCI X2MissionTemplate]
-DisplayName="Operation Gatecrasher"
-Briefing="ADVENT has brought a pair of dissident academics to this facility for 're-education'. These two could be of extreme value to the Resistance. Ensure they both make it out of here alive."
+DisplayName="Rescue VIPs from ADVENT Compound"
+Briefing="Rescue VIPs from ADVENT Compound"
 PostMissionType="Operation Gatecrasher"
 BriefingImage="img:///UILibrary_Common.Xcom_default"
 ObjectiveTextPools[0]="Sweep the site and eliminate all hostiles"
 ObjectiveTextPools[1]="Rescue the prisoners from their prison cells"
 ObjectiveTextPools[2]="Keep prisoners alive until the site is cleared"
-PreMissionNarratives[0]="X2NarrativeMoments.TACTICAL.RescueVIP.Central_Council_Missions_Rescue_VIP_01"
-PreMissionNarratives[1]="X2NarrativeMoments.TACTICAL.RescueVIP.Central_Council_Missions_Rescue_VIP_02"
-PreMissionNarratives[2]="X2NarrativeMoments.TACTICAL.RescueVIP.Central_Council_Missions_Rescue_VIP_03"
-PreMissionNarratives[3]="X2NarrativeMoments.TACTICAL.RescueVIP.Central_Council_Missions_Rescue_VIP_04"
-PreMissionNarratives[4]="X2NarrativeMoments.TACTICAL.RescueVIP.Central_Council_Missions_Rescue_VIP_05"
+PreMissionNarratives[0]="X2NarrativeMoments.TACTICAL.SabotageCC.T_SabotageCC_Narrative_Wrappers_04"
 
 [MissionSource_GatecrasherCI X2MissionSourceTemplate]
 +BattleOpName="Operation Gatecrasher"

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/SeqAct_ForceInteractiveObjectTacticalHack.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/SeqAct_ForceInteractiveObjectTacticalHack.uc
@@ -1,0 +1,49 @@
+//---------------------------------------------------------------------------------------
+//  AUTHOR:  NotSoLoneWolf
+//  PURPOSE: This sequence action is used in kismet to override an object's hack rewards,
+//           removing all strategic resource rewards and editing hack defense
+//---------------------------------------------------------------------------------------
+//  WOTCStrategyOverhaul Team
+//---------------------------------------------------------------------------------------
+
+class SeqAct_ForceInteractiveObjectTacticalHack extends SequenceAction;
+
+var XComGameState_InteractiveObject InteractiveObject;
+var int HackDefense;
+
+event Activated()
+{
+    local XComGameState NewGameState;
+    local XComGameState_InteractiveObject NewInteractiveObject;
+	local array<name> OldHackRewards, NewHackRewards;
+	
+    if (InteractiveObject != none)
+    {
+		OldHackRewards = InteractiveObject.GetHackRewards('');
+		`TACTICALMISSIONMGR.SelectHackRewards('PureTacticalHackRewards', '', NewHackRewards);
+		NewHackRewards.InsertItem(0, OldHackRewards[0]);
+		
+        NewGameState = class'XComGameStateContext_ChangeContainer'.static.CreateChangeState("SeqAct_ForceInteractiveObjectTacticalHack: " @ InteractiveObject.GetVisualizer() @ " (" @ InteractiveObject.ObjectID @ ")");
+        NewInteractiveObject = XComGameState_InteractiveObject(NewGameState.CreateStateObject(class'XComGameState_InteractiveObject', InteractiveObject.ObjectID));
+        
+		NewInteractiveObject.SetLocked(HackDefense);
+		NewInteractiveObject.bOffersStrategyHackRewards = false;
+		NewInteractiveObject.bOffersTacticalHackRewards = true;
+		NewInteractiveObject.SetHackRewards(class'X2HackRewardTemplateManager'.static.SelectHackRewards(NewHackRewards));
+
+		NewGameState.AddStateObject(NewInteractiveObject);
+        `TACTICALRULES.SubmitGameState(NewGameState);
+    }
+}
+
+defaultproperties
+{
+    ObjName="Force Interactive Object Tactical Hack"
+    ObjCategory="CovertInfiltration"
+    bConvertedForReplaySystem=true
+    bCanBeUsedForGameplaySequence=true
+
+    VariableLinks.Empty
+    VariableLinks(0)=(ExpectedType=class'SeqVar_InteractiveObject',LinkDesc="Interactive Object",PropertyName=InteractiveObject,bWriteable=false)
+    VariableLinks(1)=(ExpectedType=class'SeqVar_Int',LinkDesc="Hack Defense",PropertyName=HackDefense,bWriteable=false)
+}

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2DownloadableContentInfo_CovertInfiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2DownloadableContentInfo_CovertInfiltration.uc
@@ -226,6 +226,7 @@ static function ReplaceGatecrasher (XComGameState StartState)
 		StartState.RemoveStateObject(MissionState.ObjectID);
 
 		CreateStartingMission(StartState, StartingMissionLoc);
+		PopulatePureTacticalRewardDeck();
 
 		`CI_Trace("Gatecrasher Replaced!");
 	}
@@ -297,6 +298,36 @@ private static function AddTacticalTagToRewardUnit(XComGameState NewGameState, X
 	if (UnitState != none)
 	{
 		UnitState.TacticalTag = TacticalTag;
+	}
+}
+
+static function PopulatePureTacticalRewardDeck ()
+{
+	local X2CardManager CardManager;
+	local X2DataTemplate DataTemplate;
+	local X2HackRewardTemplateManager HackRewardTemplateManager;
+	local X2HackRewardTemplate HackRewardTemplate;
+
+	CardManager = class'X2CardManager'.static.GetCardManager();
+
+	HackRewardTemplateManager = class'X2HackRewardTemplateManager'.static.GetHackRewardTemplateManager();
+
+	foreach HackRewardTemplateManager.IterateTemplates(DataTemplate, None)
+	{
+		HackRewardTemplate = X2HackRewardTemplate(DataTemplate);
+
+		if( HackRewardTemplate.bIsNegativeTacticalReward && !HackRewardTemplate.bIsNegativeStrategyReward )
+		{
+			CardManager.AddCardToDeck('NegativePureTacticalHackRewards', string(HackRewardTemplate.DataName));
+		}
+
+		if( HackRewardTemplate.bIsTier1Reward || HackRewardTemplate.bIsTier2Reward )
+		{
+			if( HackRewardTemplate.bIsTacticalReward && !HackRewardTemplate.bIsStrategyReward )
+			{
+				CardManager.AddCardToDeck('PureTacticalHackRewards', string(HackRewardTemplate.DataName));
+			}
+		}
 	}
 }
 

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2MissionNarrative_InfiltrationNarrativeSet.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2MissionNarrative_InfiltrationNarrativeSet.uc
@@ -22,7 +22,7 @@ static function X2MissionNarrativeTemplate AddDefaultGatecrasherMissionNarrative
     Template.NarrativeMoments[2]="XPACK_NarrativeMoments.X2_XP_CEN_T_Comp_Rescue_Operative_Recovered_Squad_Wipe";
     Template.NarrativeMoments[3]="XPACK_NarrativeMoments.X2_XP_CEN_T_Comp_Rescue_Operative_Recovered_Heavy_Losses";
     Template.NarrativeMoments[4]="XPACK_NarrativeMoments.X2_XP_CEN_T_Comp_Rescue_Operative_Not_Recovered";
-    Template.NarrativeMoments[5]="XPACK_NarrativeMoments.X2_XP_CEN_T_Comp_Rescue_Mission_Intro";
+    Template.NarrativeMoments[5]="X2NarrativeMoments.TACTICAL.RescueVIP.CEN_RescVEH_Intro";
     Template.NarrativeMoments[6]="XPACK_NarrativeMoments.X2_XP_CEN_T_Comp_Rescue_Mission_Accomplished";
 	
     return Template;


### PR DESCRIPTION
Closes #534 

Hidden within the kismet file, I used the new SeqAct I made to change the doors' hack defense from 60 to 10. With the standard soldier hack offense of 5, that means the chance to get the T1 hack reward is around 35%, which should incentivize freeing the prisoners first rather than clearing the site before heading to the cells. All other changes are visible in the github diffs.