### PR TITLE
Ensure a scanning site spawns if none are available

### DIFF
--- a/CovertInfiltration/Config/XComGameData.ini
+++ b/CovertInfiltration/Config/XComGameData.ini
@@ -106,11 +106,7 @@ m_iMaxSoldiersOnMission=6
 ; Disable CA ambush safeguard
 CovertActionAmbushSafeguardDays=0
 
-; Always spawn another scanning site when there are 0 available
--AdditionalPOIChance[0]=50 ;Easy
--AdditionalPOIChance[1]=50 ;Normal
--AdditionalPOIChance[2]=50 ;Classic
--AdditionalPOIChance[3]=50 ;Impossible
+; Chance to spawn another scanning site when there are less than 3 available
 +AdditionalPOIChance[0]=100 ;Easy
 +AdditionalPOIChance[1]=100 ;Normal
 +AdditionalPOIChance[2]=100 ;Classic

--- a/CovertInfiltration/Config/XComGameData.ini
+++ b/CovertInfiltration/Config/XComGameData.ini
@@ -106,6 +106,16 @@ m_iMaxSoldiersOnMission=6
 ; Disable CA ambush safeguard
 CovertActionAmbushSafeguardDays=0
 
+; Always spawn another scanning site when there are 0 available
+-AdditionalPOIChance[0]=50 ;Easy
+-AdditionalPOIChance[1]=50 ;Normal
+-AdditionalPOIChance[2]=50 ;Classic
+-AdditionalPOIChance[3]=50 ;Impossible
++AdditionalPOIChance[0]=100 ;Easy
++AdditionalPOIChance[1]=100 ;Normal
++AdditionalPOIChance[2]=100 ;Classic
++AdditionalPOIChance[3]=100 ;Impossible
+
 [XComGame.XComGameState_HeadquartersXCom]
 ; Increase the amount of loot drops as we have more people to give things to now
 TimedLootPerMission=3


### PR DESCRIPTION
Closes #500 

By default, when a POI is completed, the game checks to see if there are less than 3 POIs remaining. If so, there's a 50% chance for a new POI to be spawned immediately.

The less than 3 part is hardcoded and would require a highlander edit, but the 50% part is exposed to config, so I flipped it to 100% on all difficulties.

If the player chooses to sit at HQ and not scan any POIs, they will still run out of POIs, but another will spawn when a mission with the associated reward is completed, and when that one is scanned the logic described above will trigger to give the player another POI.