### PR TITLE
Improvements to sabotage monument missions

### DIFF
--- a/CovertInfiltration/Config/XComGameData.ini
+++ b/CovertInfiltration/Config/XComGameData.ini
@@ -218,6 +218,8 @@ NumDarkEventsThirdMonth = 3
 +SITREPS_MISSION_BLACKLIST=(MissionType="GatherSurvivors", SitRep="WellRehearsed")
 +SITREPS_MISSION_BLACKLIST=(MissionType="GatherSurvivors", SitRep="GunneryEmplacements")
 +SITREPS_MISSION_BLACKLIST=(MissionType="ExtractVIP", SitRep="LightningStrike")
++SITREPS_MISSION_BLACKLIST=(MissionType="SabotageCC", SitRep="ShoddyIntel")
++SITREPS_MISSION_BLACKLIST=(MissionType="SabotageCC", SitRep="WellRehearsed")
 
 [MentalReadiness X2SitRepTemplate]
 +TacticalGameplayTags=SITREP_PhysicalConditioning

--- a/CovertInfiltration/Content/Maps/Missions/Obj_SabotageCC_CI.umap
+++ b/CovertInfiltration/Content/Maps/Missions/Obj_SabotageCC_CI.umap
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c22245dd074740cb7333269783f90720db263108a6c354b5115b8c051b914eef
-size 350594
+oid sha256:4447fcee87d3e179c5c2b0abf39a9fa51df7339f2615ccfd1406fc08d308a3bc
+size 350486

--- a/CovertInfiltration/Content/Maps/Missions/Obj_SabotageCC_CI.umap
+++ b/CovertInfiltration/Content/Maps/Missions/Obj_SabotageCC_CI.umap
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c22245dd074740cb7333269783f90720db263108a6c354b5115b8c051b914eef
+size 350594

--- a/CovertInfiltration/CovertInfiltration.x2proj
+++ b/CovertInfiltration/CovertInfiltration.x2proj
@@ -76,6 +76,9 @@
     <Content Include="Content\Maps\Missions\Obj_Gatecrasher_CI.umap">
       <SubType>Content</SubType>
     </Content>
+    <Content Include="Content\Maps\Missions\Obj_SabotageCC_CI.umap">
+      <SubType>Content</SubType>
+    </Content>
     <Content Include="Content\Maps\Missions\Obj_SupplyExtraction_CI.umap">
       <SubType>Content</SubType>
     </Content>

--- a/CovertInfiltration/Localization/XComGame.int
+++ b/CovertInfiltration/Localization/XComGame.int
@@ -374,8 +374,8 @@ ConsoleObjectiveTextPools[1]=
 
 [DefaultSabotageCC X2MissionNarrativeTemplate]
 ObjectiveTextPools[0]="Unused"
-ObjectiveTextPools[1]="Extract all XCOM soldiers"
-ObjectiveTextPools[2]="Plant X4 charges on the monument"
+ObjectiveTextPools[1]="Plant X4 charges on the monument"
+ObjectiveTextPools[2]="Extract all XCOM soldiers"
 
 [GatecrasherCI X2MissionTemplate]
 DisplayName="Operation Gatecrasher"

--- a/CovertInfiltration/Localization/XComGame.int
+++ b/CovertInfiltration/Localization/XComGame.int
@@ -372,6 +372,11 @@ ObjectiveTextPools[3]="Prisoners Must Survive"
 ConsoleObjectiveTextPools[0]=
 ConsoleObjectiveTextPools[1]=
 
+[DefaultSabotageCC X2MissionNarrativeTemplate]
+ObjectiveTextPools[0]="Unused"
+ObjectiveTextPools[1]="Extract all XCOM soldiers"
+ObjectiveTextPools[2]="Plant X4 charges on the monument"
+
 [GatecrasherCI X2MissionTemplate]
 DisplayName="Operation Gatecrasher"
 Briefing="Break into ADVENT Compound and Rescue VIPs"

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2DownloadableContentInfo_CovertInfiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2DownloadableContentInfo_CovertInfiltration.uc
@@ -489,7 +489,8 @@ static event OnPostTemplatesCreated()
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchQuestItems();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchAlienNetworkMissionSource();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchSabotageMonumentMissionSchedules();
-	class'X2Helper_Infiltration_TemplateMod'.static.PatchSupplyExtractionMission();
+	class'X2Helper_Infiltration_TemplateMod'.static.PatchMissionDefinitions();
+	class'X2Helper_Infiltration_TemplateMod'.static.PatchSabotageMissionNarrative();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchItemStats();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchFacilityLeadPOI();
 	class'X2Helper_Infiltration_TemplateMod'.static.PatchFacilityLeadItem();

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
@@ -542,10 +542,10 @@ static function PatchSabotageMonumentMissionSchedules ()
 	}
 }
 
-static function PatchSupplyExtractionMission ()
+static function PatchMissionDefinitions ()
 {
 	local XComTacticalMissionManager MissionManager;
-	local MissionObjectiveDefinition ExtractObjective;
+	local MissionObjectiveDefinition ExtractObjective, SweepObjective, DestroyObjective;
 	local int i;
 
 	MissionManager = `TACTICALMISSIONMGR;
@@ -564,6 +564,59 @@ static function PatchSupplyExtractionMission ()
 			MissionManager.arrMissions[i].MapNames[0] = "Obj_SupplyExtraction_CI";
 			MissionManager.arrMissions[i].MissionObjectives[1] = ExtractObjective;
 		}
+
+		if (MissionManager.arrMissions[i].sType == "SabotageCC"
+		 || MissionManager.arrMissions[i].MissionName == 'SabotageAdventMonument')
+		{
+			SweepObjective.ObjectiveName = 'Sweep';
+			SweepObjective.bIsTacticalObjective = true;
+			SweepObjective.bIsStrategyObjective = false;
+			SweepObjective.bIsTriadObjective = false;
+
+			DestroyObjective.ObjectiveName = 'Destroy';
+			DestroyObjective.bIsTacticalObjective = false;
+			DestroyObjective.bIsStrategyObjective = true;
+			DestroyObjective.bIsTriadObjective = true;
+			
+			MissionManager.arrMissions[i].MapNames[0] = "Obj_SabotageCC_CI";
+			MissionManager.arrMissions[i].MissionObjectives[0] = SweepObjective;
+			MissionManager.arrMissions[i].MissionObjectives[1] = DestroyObjective;
+		}
+	}
+}
+
+static function PatchSabotageMissionNarrative ()
+{
+	local X2MissionNarrativeTemplateManager TemplateManager;
+	local X2MissionNarrativeTemplate        Template;
+
+	TemplateManager = class'X2MissionNarrativeTemplateManager'.static.GetMissionNarrativeTemplateManager();
+	Template = TemplateManager.FindMissionNarrativeTemplate("SabotageCC");
+
+	if (Template != none)
+	{
+		// Old
+		Template.NarrativeMoments[0]="X2NarrativeMoments.TACTICAL.SabotageCC.SabotageCC_BombDetonated";
+		Template.NarrativeMoments[1]="X2NarrativeMoments.TACTICAL.SabotageCC.SabotageCC_HeavyLossesIncurred";
+		Template.NarrativeMoments[2]="X2NarrativeMoments.TACTICAL.SabotageCC.SabotageCC_TacIntro";
+		Template.NarrativeMoments[3]="X2NarrativeMoments.TACTICAL.SabotageCC.SabotageCC_BombSpotted";
+		Template.NarrativeMoments[4]="X2NarrativeMoments.TACTICAL.General.GenTactical_SquadWipe";
+		Template.NarrativeMoments[5]="X2NarrativeMoments.TACTICAL.SabotageCC.SabotageCC_CompletionNag";
+		Template.NarrativeMoments[6]="X2NarrativeMoments.TACTICAL.SabotageCC.SabotageCC_AllEnemiesDefeated";
+		Template.NarrativeMoments[9]="X2NarrativeMoments.TACTICAL.SabotageCC.SabotageCC_BombPlantedContinue";
+
+		// Replaced
+		//Template.NarrativeMoments[7]="X2NarrativeMoments.TACTICAL.SabotageCC.SabotageCC_AreaSecuredMissionEnd";
+		Template.NarrativeMoments[7]="X2NarrativeMoments.TACTICAL.Sabotage.Sabotage_AllEnemiesDefeatedObjCompleted";
+		//Template.NarrativeMoments[8]="X2NarrativeMoments.TACTICAL.SabotageCC.SabotageCC_BombPlantedEnd";
+		Template.NarrativeMoments[8]="X2NarrativeMoments.TACTICAL.Sabotage.Sabotage_BombPlantedNoRNF";
+
+		// New
+		Template.NarrativeMoments[10]="X2NarrativeMoments.TACTICAL.General.GenTactical_PartialEVAC";
+		Template.NarrativeMoments[11]="X2NarrativeMoments.TACTICAL.General.GenTactical_FullEVAC";
+		Template.NarrativeMoments[12]="X2NarrativeMoments.TACTICAL.General.GenTactical_MissionExtroFailure";
+		Template.NarrativeMoments[13]="X2NarrativeMoments.TACTICAL.Sabotage.Sabotage_SignalJammed";
+		Template.NarrativeMoments[14]="X2NarrativeMoments.TACTICAL.Sabotage.Sabotage_RNFIncoming";
 	}
 }
 

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration_TemplateMod.uc
@@ -553,7 +553,7 @@ static function PatchMissionDefinitions ()
 	for (i = 0; i < MissionManager.arrMissions.Length; i++)
 	{
 		if (MissionManager.arrMissions[i].sType == "SupplyExtraction"
-		 || MissionManager.arrMissions[i].MissionName == 'SupplyExtraction')
+		 && MissionManager.arrMissions[i].MissionName == 'SupplyExtraction')
 		{
 			ExtractObjective.ObjectiveName = 'ExtractAll';
 			ExtractObjective.bIsTacticalObjective = false;
@@ -566,7 +566,7 @@ static function PatchMissionDefinitions ()
 		}
 
 		if (MissionManager.arrMissions[i].sType == "SabotageCC"
-		 || MissionManager.arrMissions[i].MissionName == 'SabotageAdventMonument')
+		 && MissionManager.arrMissions[i].MissionName == 'SabotageAdventMonument')
 		{
 			SweepObjective.ObjectiveName = 'Sweep';
 			SweepObjective.bIsTacticalObjective = true;


### PR DESCRIPTION
Closes #575 
Closes #583 
Also lays the groundwork for further changes to that mission if we want to later by setting up the kismet necessary to handle extraction of XCOM soldiers. Could be converted into an infinite reinforcements mission fairly easily.