### PR TITLE
Prevent promotions CA from spawning if slot rewards have been removed

### DIFF
--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2StrategyElement_InfiltrationRewards.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2StrategyElement_InfiltrationRewards.uc
@@ -85,7 +85,29 @@ static function X2DataTemplate CreatePromotionsRewardTemplate()
 	// This is a dummy reward, does nothing
 	`CREATE_X2Reward_TEMPLATE(Template, 'Reward_Promotions');
 
+	Template.IsRewardAvailableFn = IsPromotionsRewardAvailable;
+
 	return Template;
+}
+
+static function bool IsPromotionsRewardAvailable(optional XComGameState NewGameState, optional StateObjectReference AuxRef)
+{
+	local X2CovertActionTemplate ActionTemplate;
+	local X2StrategyElementTemplateManager TemplateManager;
+
+	TemplateManager = class'X2StrategyElementTemplateManager'.static.GetStrategyElementTemplateManager();
+	ActionTemplate = X2CovertActionTemplate(TemplateManager.FindStrategyElementTemplate('CovertAction_ExhaustiveTraining'));
+
+	if (ActionTemplate != none)
+	{
+		return ActionTemplate.Slots[0].Rewards.Length > 0;
+	}
+	else
+	{
+		`Redscreen("CI: Promotions reward is not available because the covert action template was not found");
+	}
+
+	return false;
 }
 
 static function X2DataTemplate CreateSmallIntelRewardTemplate()

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2StrategyElement_InfiltrationRewards.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2StrategyElement_InfiltrationRewards.uc
@@ -102,10 +102,8 @@ static function bool IsPromotionsRewardAvailable(optional XComGameState NewGameS
 	{
 		return ActionTemplate.Slots[0].Rewards.Length > 0;
 	}
-	else
-	{
-		`Redscreen("CI: Promotions reward is not available because the covert action template was not found");
-	}
+
+	`Redscreen("CI: Promotions reward is not available because the covert action template was not found");
 
 	return false;
 }


### PR DESCRIPTION
Closes #552 
Detects OPTC changes to the covert action template and flags the associated reward as unavailable, preventing the spawning of the covert action.