### PR TITLE
Exclude some sitreps from spawning on assaults

### DIFF
--- a/CovertInfiltration/Config/XComInfiltration.ini
+++ b/CovertInfiltration/Config/XComInfiltration.ini
@@ -49,12 +49,12 @@ ENVIROMENTAL_SITREP_CHANCE=50
 
 +FlatRiskSitReps=(FlatRiskName="CovertActionRisk_ShoddyIntel",         SitRepName="ShoddyIntel")
 +FlatRiskSitReps=(FlatRiskName="CovertActionRisk_AdventAirPatrols",    SitRepName="AdventAirPatrols")
-+FlatRiskSitReps=(FlatRiskName="CovertActionRisk_IntelligenceLeak",    SitRepName="IntelligenceLeak")
++FlatRiskSitReps=(FlatRiskName="CovertActionRisk_IntelligenceLeak",    SitRepName="IntelligenceLeak", InfiltrationOnly=true)
 +FlatRiskSitReps=(FlatRiskName="CovertActionRisk_UpdatedFirewalls",    SitRepName="UpdatedFirewalls")
 +FlatRiskSitReps=(FlatRiskName="CovertActionRisk_Phalanx_CI",          SitRepName="Phalanx_CI")
 +FlatRiskSitReps=(FlatRiskName="CovertActionRisk_Congregation",        SitRepName="Congregation")
-+FlatRiskSitReps=(FlatRiskName="CovertActionRisk_MessyInsertion",      SitRepName="MessyInsertion")
-+FlatRiskSitReps=(FlatRiskName="CovertActionRisk_RestrictedAirspace",  SitRepName="RestrictedAirspace")
++FlatRiskSitReps=(FlatRiskName="CovertActionRisk_MessyInsertion",      SitRepName="MessyInsertion", InfiltrationOnly=true)
++FlatRiskSitReps=(FlatRiskName="CovertActionRisk_RestrictedAirspace",  SitRepName="RestrictedAirspace", InfiltrationOnly=true)
 +FlatRiskSitReps=(FlatRiskName="CovertActionRisk_ExperimentalRollout", SitRepName="ExperimentalRollout")
 
 ; New GTS training values

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/CI_DataStructures.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/CI_DataStructures.uc
@@ -44,6 +44,7 @@ struct ActionFlatRiskSitRep
 {
 	var name FlatRiskName;
 	var name SitRepName;
+	var bool InfiltrationOnly;
 };
 
 struct DelayedReinforcementOrder

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
@@ -719,7 +719,10 @@ static function BuildFlatRisksDeck ()
 	
 	foreach default.FlatRiskSitReps(FlatRiskDef)
 	{
-		CardManager.AddCardToDeck('FlatRisks', string(FlatRiskDef.FlatRiskName));
+		if (!FlatRiskDef.InfiltrationOnly)
+		{
+			CardManager.AddCardToDeck('FlatRisks', string(FlatRiskDef.FlatRiskName));
+		}
 	}
 }
 

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
@@ -719,10 +719,7 @@ static function BuildFlatRisksDeck ()
 	
 	foreach default.FlatRiskSitReps(FlatRiskDef)
 	{
-		if (!FlatRiskDef.InfiltrationOnly)
-		{
-			CardManager.AddCardToDeck('FlatRisks', string(FlatRiskDef.FlatRiskName));
-		}
+		CardManager.AddCardToDeck('FlatRisks', string(FlatRiskDef.FlatRiskName));
 	}
 }
 
@@ -791,7 +788,7 @@ static function array<name> GetSitrepsForAssaultMission (XComGameState_MissionSi
 		{
 			i = default.FlatRiskSitReps.Find('FlatRiskName', name(Card));
 
-			if (i != INDEX_NONE)
+			if (i != INDEX_NONE && !default.FlatRiskSitReps[i].InfiltrationOnly)
 			{
 				SitRepTemplate = SitRepManager.FindSitRepTemplate(default.FlatRiskSitReps[i].SitRepName);
 


### PR DESCRIPTION
Closes #648 

In addition to Messy Insertion, I also tossed in Restricted Airspace and Intelligence Leak for thematic reasons. (Because in assaults you arrive on the skyranger, why can't you leave in it? And how does the operation leak if you fly directly there?)