### PR TITLE
Nest the tired check inside the deployable check to prevent unavailable soldiers being reported as tired

### DIFF
--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
@@ -1052,14 +1052,14 @@ static function BarracksStatusReport GetBarracksStatusReport()
 		}
 		else if (Soldier.CanGoOnMission())
 		{
-            if (Soldier.GetMentalState() == eMentalState_Tired)
-            {
-                CurrentBarracksStatus.Tired++;
-            }
-            else
-            {
-                CurrentBarracksStatus.Ready++;
-            }
+			if (Soldier.GetMentalState() == eMentalState_Tired)
+			{
+				CurrentBarracksStatus.Tired++;
+			}
+			else
+			{
+				CurrentBarracksStatus.Ready++;
+			}
 		}
 		else
 		{

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
@@ -1050,6 +1050,10 @@ static function BarracksStatusReport GetBarracksStatusReport()
 		{
 			CurrentBarracksStatus.Wounded++;
 		}
+		else if (Soldier.bCaptured)
+		{
+			continue;
+		}
 		else if (Soldier.CanGoOnMission())
 		{
 			if (Soldier.GetMentalState() == eMentalState_Tired)

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
@@ -1038,7 +1038,11 @@ static function BarracksStatusReport GetBarracksStatusReport()
 
 	foreach Soldiers(Soldier)
 	{
-		if (Soldier.GetStaffSlot() != none && Soldier.GetStaffSlot().GetMyTemplateName() == 'InfiltrationStaffSlot')
+		if (Soldier.bCaptured)
+		{
+			continue;
+		}
+		else if (Soldier.GetStaffSlot() != none && Soldier.GetStaffSlot().GetMyTemplateName() == 'InfiltrationStaffSlot')
 		{
 			CurrentBarracksStatus.Infiltrating++;
 		}
@@ -1049,10 +1053,6 @@ static function BarracksStatusReport GetBarracksStatusReport()
 		else if (Soldier.IsInjured())
 		{
 			CurrentBarracksStatus.Wounded++;
-		}
-		else if (Soldier.bCaptured)
-		{
-			continue;
 		}
 		else if (Soldier.CanGoOnMission())
 		{

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/X2Helper_Infiltration.uc
@@ -1050,13 +1050,16 @@ static function BarracksStatusReport GetBarracksStatusReport()
 		{
 			CurrentBarracksStatus.Wounded++;
 		}
-		else if (Soldier.GetMentalState() == eMentalState_Tired)
-		{
-			CurrentBarracksStatus.Tired++;
-		}
 		else if (Soldier.CanGoOnMission())
 		{
-			CurrentBarracksStatus.Ready++;
+            if (Soldier.GetMentalState() == eMentalState_Tired)
+            {
+                CurrentBarracksStatus.Tired++;
+            }
+            else
+            {
+                CurrentBarracksStatus.Ready++;
+            }
 		}
 		else
 		{


### PR DESCRIPTION
Closes #663 