### PR TITLE
add event after `UICovertActionsGeoscape.UpdateData()`

### DIFF
--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
@@ -791,7 +791,7 @@ simulated function UpdateData()
 
 	TriggerTutorialOnSelection();
 
-	`XEVENTMGR.TriggerEvent('CI_UICovertActionsGeoscape_UpdateData', self, self, none);
+	`XEVENTMGR.TriggerEvent('CI_UICovertActionsGeoscape_PostUpdateData', self, self, none);
 }
 
 simulated function bool CanOpenLoadout()

--- a/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
+++ b/CovertInfiltration/Src/CovertInfiltration/Classes/UICovertActionsGeoscape.uc
@@ -790,6 +790,8 @@ simulated function UpdateData()
 	}
 
 	TriggerTutorialOnSelection();
+
+	`XEVENTMGR.TriggerEvent('CI_UICovertActionsGeoscape_UpdateData', self, self, none);
 }
 
 simulated function bool CanOpenLoadout()


### PR DESCRIPTION
Add an event after `UICovertActionsGeoscape.UpdateData()`. This allows a UIScreenListener to react to user input on this screen.